### PR TITLE
Add confirm form element which allows to confirm form fields via double-input

### DIFF
--- a/modules/civiremote_event/src/Element/Confirm.php
+++ b/modules/civiremote_event/src/Element/Confirm.php
@@ -1,0 +1,118 @@
+<?php
+/*
+ * Copyright (C) 2023 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation in version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Drupal\civiremote_event\Element;
+
+use Drupal\Core\Render\Element\FormElement;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Provides a form element for double-input of values.
+ *
+ * Formats as a pair of fields, which do not validate unless the two entered
+ * values match.
+ *
+ * Properties:
+ * - #field: The render array of the form field to confirm.
+ * - #confirm_title: The title of the confirmation field (optional).
+ *
+ * @FormElement("confirm")
+ */
+final class Confirm extends FormElement {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getInfo(): array {
+    return [
+      '#field' => [],
+      '#confirm_title' => NULL,
+      '#input' => TRUE,
+      '#markup' => '',
+      '#process' => [
+        [static::class, 'processConfirm'],
+      ],
+      '#theme_wrappers' => [
+        'form_element',
+      ],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function valueCallback(&$element, $input, FormStateInterface $form_state): array {
+    if ($input === FALSE) {
+      return $element['#default_value'] = [
+        'value1' => $element['#field']['#default_value'] ?? NULL,
+        'value2' => $element['#field']['#default_value'] ?? NULL,
+      ];
+    }
+
+    /** @phpstan-var array<string, mixed> $input */
+    return [
+      'value1' => $input['value1'] ?? $element['#field']['#default_value'] ?? NULL,
+      'value2' => $input['value2'] ?? $element['#field']['#default_value'] ?? NULL,
+    ];
+  }
+
+  /**
+   * Expand a confirm field into two fields.
+   */
+  public static function processConfirm(array &$element, FormStateInterface $formState, array &$form): array {
+    if (isset($element['#field']['#name'])) {
+      $element['#name'] = $element['#field']['#name'];
+      unset($element['#field']['#name']);
+    }
+
+    $element['value1'] = [
+      '#value' => $element['#value']['value1'],
+    ] + $element['#field'];
+
+    $element['value2'] = [
+      '#title' => $element['#confirm_title'] ?? t('@fieldTitle (Confirm)', ['@fieldTitle' => $element['#field']['#title']]),
+      '#value' => $element['#value']['value2'],
+    ] + $element['#field'];
+
+    $element['#element_validate'] = [
+      [static::class, 'validateConfirm'],
+    ];
+    $element['#tree'] = TRUE;
+
+    return $element;
+  }
+
+  public static function validateConfirm(array &$element, FormStateInterface $formState, array &$form): array {
+    $value1 = $element['value1']['#value'];
+    $value2 = $element['value2']['#value'];
+
+    if ($value1 !== $value2) {
+      $formState->setError($element['value2'], t('The confirmation does not match.'));
+    }
+
+    // Field must be converted from a two-element array into a single
+    // value regardless of validation results.
+    $formState->setValueForElement($element['value1'], NULL);
+    $formState->setValueForElement($element['value2'], NULL);
+    $formState->setValueForElement($element, $value1);
+
+    return $element;
+  }
+
+}

--- a/modules/civiremote_event/src/Form/RegisterForm.php
+++ b/modules/civiremote_event/src/Form/RegisterForm.php
@@ -679,7 +679,7 @@ class RegisterForm extends FormBase implements RegisterFormInterface {
       if (($field['confirm_required'] ?? FALSE) === TRUE) {
         $group[$field_name] = [
           '#type' => 'confirm',
-          '#field' => $group[$field_name],
+          '#element' => $group[$field_name],
         ];
       }
     }

--- a/modules/civiremote_event/src/Form/RegisterForm.php
+++ b/modules/civiremote_event/src/Form/RegisterForm.php
@@ -675,6 +675,13 @@ class RegisterForm extends FormBase implements RegisterFormInterface {
 
       // Display prefix/suffix content.
       $this->addPrefixSuffix($field, $field_name, $group);
+
+      if (($field['confirm_required'] ?? FALSE) === TRUE) {
+        $group[$field_name] = [
+          '#type' => 'confirm',
+          '#field' => $group[$field_name],
+        ];
+      }
     }
 
     // Collapse fieldsets with more than 10 children.

--- a/translations/civiremote.pot
+++ b/translations/civiremote.pot
@@ -3,31 +3,35 @@
 # LANGUAGE translation of CiviRemote
 # Copyright YEAR NAME <EMAIL@ADDRESS>
 # Generated from files:
-#  modules/custom/civiremote/civiremote.tokens.inc: n/a
-#  modules/custom/civiremote/civiremote.module: n/a
-#  modules/custom/civiremote/civiremote.info.yml: n/a
-#  modules/custom/civiremote/civiremote.links.menu.yml: n/a
-#  modules/custom/civiremote/modules/civiremote_event/civiremote_event.info.yml: n/a
-#  modules/custom/civiremote/civiremote.permissions.yml: n/a
-#  modules/custom/civiremote/civiremote.routing.yml: n/a
-#  modules/custom/civiremote/config/schema/civiremote.schema.yml: n/a
-#  modules/custom/civiremote/src/Plugin/Action/UserMatchContact.php: n/a
-#  modules/custom/civiremote/src/Plugin/Action/UserSynchroniseRoles.php: n/a
-#  modules/custom/civiremote/js/dialog.js: n/a
-#  modules/custom/civiremote/modules/civiremote_event/civiremote_event.links.menu.yml: n/a
-#  modules/custom/civiremote/modules/civiremote_event/civiremote_event.routing.yml: n/a
-#  modules/custom/civiremote/modules/civiremote_event/config/schema/civiremote_event.schema.yml: n/a
-#  modules/custom/civiremote/modules/civiremote_event/src/Form/CiviRemoteEventConfigForm.php: n/a
-#  modules/custom/civiremote/modules/civiremote_event/src/CiviMRF.php: n/a
-#  modules/custom/civiremote/src/Form/CiviRemoteConfigForm.php: n/a
-#  modules/custom/civiremote/modules/civiremote_event/src/Form/RegisterForm.php: n/a
-#  modules/custom/civiremote/modules/civiremote_event/src/Form/RegistrationCancelForm.php: n/a
+#  civiremote.tokens.inc: n/a
+#  civiremote.module: n/a
+#  civiremote.info.yml: n/a
+#  civiremote.links.menu.yml: n/a
+#  config/install/cmrf_core.cmrf_connector.civiremote.yml: n/a
+#  modules/civiremote_event/civiremote_event.info.yml: n/a
+#  civiremote.permissions.yml: n/a
+#  civiremote.routing.yml: n/a
+#  config/schema/civiremote.schema.yml: n/a
+#  src/Plugin/Action/UserMatchContact.php: n/a
+#  src/Plugin/Action/UserSynchroniseRoles.php: n/a
+#  js/dialog.js: n/a
+#  modules/civiremote_event/civiremote_event.links.menu.yml: n/a
+#  modules/civiremote_event/civiremote_event.permissions.yml: n/a
+#  modules/civiremote_event/civiremote_event.routing.yml: n/a
+#  modules/civiremote_event/config/schema/civiremote_event.schema.yml: n/a
+#  modules/civiremote_event/src/Form/CiviRemoteEventConfigForm.php: n/a
+#  modules/civiremote_event/src/CiviMRF.php: n/a
+#  modules/civiremote_event/src/Element/Confirm.php: n/a
+#  modules/civiremote_event/src/Form/CheckinForm.php: n/a
+#  modules/civiremote_event/src/Form/RegisterForm.php: n/a
+#  src/Form/CiviRemoteConfigForm.php: n/a
+#  modules/civiremote_event/src/Form/RegistrationCancelForm.php: n/a
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: CiviRemote VERSION\n"
-"POT-Creation-Date: 2021-06-22 11:41+0200\n"
+"Project-Id-Version: PROJECT VERSION\n"
+"POT-Creation-Date: 2023-05-19 15:55+0200\n"
 "PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\n"
 "Last-Translator: NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
@@ -36,207 +40,247 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: modules/custom/civiremote/civiremote.tokens.inc:12 modules/custom/civiremote/civiremote.module:47
+#: civiremote.tokens.inc:12 civiremote.module:50
 msgid "CiviRemote ID"
 msgstr ""
 
-#: modules/custom/civiremote/civiremote.tokens.inc:13 modules/custom/civiremote/civiremote.module:48
+#: civiremote.tokens.inc:13 civiremote.module:51
 msgid "The unique CiviRemote ID for the user in the connected CiviCRM."
 msgstr ""
 
-#: modules/custom/civiremote/civiremote.info.yml:0 modules/custom/civiremote/civiremote.links.menu.yml:0
+#: civiremote.module:33
+msgid "Could not complete login. Please try again later or contact the site administrator."
+msgstr ""
+
+#: civiremote.info.yml:0 civiremote.links.menu.yml:0 config/install/cmrf_core.cmrf_connector.civiremote.yml:0
 msgid "CiviRemote"
 msgstr ""
 
-#: modules/custom/civiremote/civiremote.info.yml:0
+#: civiremote.info.yml:0
 msgid "Core and Tools module for CiviRemote"
 msgstr ""
 
-#: modules/custom/civiremote/civiremote.info.yml:0 modules/custom/civiremote/modules/civiremote_event/civiremote_event.info.yml:0
+#: civiremote.info.yml:0 modules/civiremote_event/civiremote_event.info.yml:0
 msgid "CiviCRM"
 msgstr ""
 
-#: modules/custom/civiremote/civiremote.links.menu.yml:0
+#: civiremote.links.menu.yml:0
 msgid "Configure settings for CiviRemote."
 msgstr ""
 
-#: modules/custom/civiremote/civiremote.permissions.yml:0
+#: civiremote.permissions.yml:0
 msgid "Administer CiviRemote"
 msgstr ""
 
-#: modules/custom/civiremote/civiremote.routing.yml:0
+#: civiremote.routing.yml:0
 msgid "CiviRemote Configuration"
 msgstr ""
 
-#: modules/custom/civiremote/config/schema/civiremote.schema.yml:0 modules/custom/civiremote/src/Plugin/Action/UserMatchContact.php:25
+#: config/schema/civiremote.schema.yml:0 src/Plugin/Action/UserMatchContact.php:25
 msgid "CiviRemote: Match contact(s)"
 msgstr ""
 
-#: modules/custom/civiremote/config/schema/civiremote.schema.yml:0 modules/custom/civiremote/src/Plugin/Action/UserSynchroniseRoles.php:24
+#: config/schema/civiremote.schema.yml:0 src/Plugin/Action/UserSynchroniseRoles.php:24
 msgid "CiviRemote: Synchronise CiviRemote roles"
 msgstr ""
 
-#: modules/custom/civiremote/js/dialog.js:0
+#: js/dialog.js:0
 msgid "Close"
 msgstr ""
 
-#: modules/custom/civiremote/modules/civiremote_event/civiremote_event.info.yml:0;0 modules/custom/civiremote/modules/civiremote_event/civiremote_event.links.menu.yml:0
+#: modules/civiremote_event/civiremote_event.info.yml:0;0 modules/civiremote_event/civiremote_event.links.menu.yml:0 modules/civiremote_event/config/optional/cmrf_views.cmrf_dataset.civiremote_event_events.yml:0
 msgid "CiviRemote Events"
 msgstr ""
 
-#: modules/custom/civiremote/modules/civiremote_event/civiremote_event.links.menu.yml:0
+#: modules/civiremote_event/civiremote_event.links.menu.yml:0
 msgid "Configure settings for CiviRemote Events."
 msgstr ""
 
-#: modules/custom/civiremote/modules/civiremote_event/civiremote_event.routing.yml:0
+#: modules/civiremote_event/civiremote_event.permissions.yml:0
+msgid "Check-in CiviCRM Event Participants"
+msgstr ""
+
+#: modules/civiremote_event/civiremote_event.permissions.yml:0
+msgid "Grants access to the check-in form for checking in CiviCRM event participants via CiviRemote."
+msgstr ""
+
+#: modules/civiremote_event/civiremote_event.routing.yml:0
 msgid "CiviRemote Events Configuration"
 msgstr ""
 
-#: modules/custom/civiremote/modules/civiremote_event/config/schema/civiremote_event.schema.yml:0 modules/custom/civiremote/modules/civiremote_event/src/Form/CiviRemoteEventConfigForm.php:42
+#: modules/civiremote_event/config/schema/civiremote_event.schema.yml:0 modules/civiremote_event/src/Form/CiviRemoteEventConfigForm.php:42
 msgid "Profile to form mapping"
 msgstr ""
 
-#: modules/custom/civiremote/modules/civiremote_event/config/schema/civiremote_event.schema.yml:0
+#: modules/civiremote_event/config/schema/civiremote_event.schema.yml:0
 msgid "Mapping of a profile ID to a form ID"
 msgstr ""
 
-#: modules/custom/civiremote/modules/civiremote_event/config/schema/civiremote_event.schema.yml:0
+#: modules/civiremote_event/config/schema/civiremote_event.schema.yml:0
 msgid "Profile ID"
 msgstr ""
 
-#: modules/custom/civiremote/modules/civiremote_event/config/schema/civiremote_event.schema.yml:0
+#: modules/civiremote_event/config/schema/civiremote_event.schema.yml:0
 msgid "Form ID"
 msgstr ""
 
-#: modules/custom/civiremote/modules/civiremote_event/config/schema/civiremote_event.schema.yml:0 modules/custom/civiremote/modules/civiremote_event/src/Form/CiviRemoteEventConfigForm.php:126
+#: modules/civiremote_event/config/schema/civiremote_event.schema.yml:0 modules/civiremote_event/src/Form/CiviRemoteEventConfigForm.php:126
 msgid "Form redirect route"
 msgstr ""
 
-#: modules/custom/civiremote/modules/civiremote_event/src/CiviMRF.php:67;103
+#: modules/civiremote_event/src/CiviMRF.php:73
 msgid "Could not retrieve remote event."
 msgstr ""
 
-#: modules/custom/civiremote/modules/civiremote_event/src/CiviMRF.php:148
+#: modules/civiremote_event/src/CiviMRF.php:118
 msgid "Retrieving form failed."
 msgstr ""
 
-#: modules/custom/civiremote/modules/civiremote_event/src/CiviMRF.php:198
+#: modules/civiremote_event/src/CiviMRF.php:168
 msgid "The event registration validation failed."
 msgstr ""
 
-#: modules/custom/civiremote/modules/civiremote_event/src/CiviMRF.php:243
+#: modules/civiremote_event/src/CiviMRF.php:213
 msgid "The event registration failed."
 msgstr ""
 
-#: modules/custom/civiremote/modules/civiremote_event/src/CiviMRF.php:288
+#: modules/civiremote_event/src/CiviMRF.php:258
 msgid "The event registration update failed."
 msgstr ""
 
-#: modules/custom/civiremote/modules/civiremote_event/src/CiviMRF.php:328
+#: modules/civiremote_event/src/CiviMRF.php:298
 msgid "The event registration cancellation failed."
 msgstr ""
 
-#: modules/custom/civiremote/modules/civiremote_event/src/Form/CiviRemoteEventConfigForm.php:43
-msgid "Define which forms should handle which CiviRemote Events profiles"
+#: modules/civiremote_event/src/CiviMRF.php:343
+msgid "The event checkin verification failed."
 msgstr ""
 
-#: modules/custom/civiremote/modules/civiremote_event/src/Form/CiviRemoteEventConfigForm.php:64
-msgid "CiviRemote Events profile ID"
+#: modules/civiremote_event/src/CiviMRF.php:386
+msgid "The event checkin failed."
 msgstr ""
 
-#: modules/custom/civiremote/modules/civiremote_event/src/Form/CiviRemoteEventConfigForm.php:65
-msgid "Drupal form ID"
+#: modules/civiremote_event/src/Element/Confirm.php:115
+msgid "@fieldTitle (Confirm)"
 msgstr ""
 
-#: modules/custom/civiremote/modules/civiremote_event/src/Form/CiviRemoteEventConfigForm.php:86 modules/custom/civiremote/src/Form/CiviRemoteConfigForm.php:152
-msgid "Remove"
+#: modules/civiremote_event/src/Element/Confirm.php:132
+msgid "The confirmation does not match."
 msgstr ""
 
-#: modules/custom/civiremote/modules/civiremote_event/src/Form/CiviRemoteEventConfigForm.php:114 modules/custom/civiremote/src/Form/CiviRemoteConfigForm.php:180
-msgid "Add mapping"
+#: modules/civiremote_event/src/Form/CheckinForm.php:125
+msgid "Check-In as %status"
 msgstr ""
 
-#: modules/custom/civiremote/modules/civiremote_event/src/Form/CiviRemoteEventConfigForm.php:127
-msgid "Enter a Drupal route that should be used as a redirect target after processing event forms. This will be overridden by a <code>destination</code> parameter in the form URL."
-msgstr ""
-
-#: modules/custom/civiremote/modules/civiremote_event/src/Form/RegisterForm.php:123
-msgid "Invalid CiviRemote Event form context"
-msgstr ""
-
-#: modules/custom/civiremote/modules/civiremote_event/src/Form/RegisterForm.php:164
-msgid "No profile found for CiviRemote event form."
-msgstr ""
-
-#: modules/custom/civiremote/modules/civiremote_event/src/Form/RegisterForm.php:539
-msgid "Submit"
-msgstr ""
-
-#: modules/custom/civiremote/modules/civiremote_event/src/Form/RegisterForm.php:551
-msgid "Next"
-msgstr ""
-
-#: modules/custom/civiremote/modules/civiremote_event/src/Form/RegisterForm.php:562
-msgid "Back"
-msgstr ""
-
-#: modules/custom/civiremote/modules/civiremote_event/src/Form/RegisterForm.php:632;677;687
-msgid "- None -"
-msgstr ""
-
-#: modules/custom/civiremote/modules/civiremote_event/src/Form/RegisterForm.php:684
-msgid "- Select -"
-msgstr ""
-
-#: modules/custom/civiremote/modules/civiremote_event/src/Form/RegisterForm.php:890;893
+#: modules/civiremote_event/src/Form/CheckinForm.php:151;154 modules/civiremote_event/src/Form/RegisterForm.php:859;862
 msgid "Yes"
 msgstr ""
 
-#: modules/custom/civiremote/modules/civiremote_event/src/Form/RegisterForm.php:890;893
+#: modules/civiremote_event/src/Form/CheckinForm.php:151;154 modules/civiremote_event/src/Form/RegisterForm.php:859;862
 msgid "No"
 msgstr ""
 
-#: modules/custom/civiremote/modules/civiremote_event/src/Form/RegisterForm.php:1081
+#: modules/civiremote_event/src/Form/CheckinForm.php:200
+msgid "Successfully checked-in the participant."
+msgstr ""
+
+#: modules/civiremote_event/src/Form/CheckinForm.php:215
+msgid "Check-in failed, please try again later."
+msgstr ""
+
+#: modules/civiremote_event/src/Form/CiviRemoteEventConfigForm.php:43
+msgid "Define which forms should handle which CiviRemote Events profiles"
+msgstr ""
+
+#: modules/civiremote_event/src/Form/CiviRemoteEventConfigForm.php:64
+msgid "CiviRemote Events profile ID"
+msgstr ""
+
+#: modules/civiremote_event/src/Form/CiviRemoteEventConfigForm.php:65
+msgid "Drupal form ID"
+msgstr ""
+
+#: modules/civiremote_event/src/Form/CiviRemoteEventConfigForm.php:86 src/Form/CiviRemoteConfigForm.php:152
+msgid "Remove"
+msgstr ""
+
+#: modules/civiremote_event/src/Form/CiviRemoteEventConfigForm.php:114 src/Form/CiviRemoteConfigForm.php:180
+msgid "Add mapping"
+msgstr ""
+
+#: modules/civiremote_event/src/Form/CiviRemoteEventConfigForm.php:127
+msgid "Enter a Drupal route that should be used as a redirect target after processing event forms. This will be overridden by a <code>destination</code> parameter in the form URL."
+msgstr ""
+
+#: modules/civiremote_event/src/Form/RegisterForm.php:124
+msgid "Invalid CiviRemote Event form context"
+msgstr ""
+
+#: modules/civiremote_event/src/Form/RegisterForm.php:156
+msgid "No profile found for CiviRemote event form."
+msgstr ""
+
+#: modules/civiremote_event/src/Form/RegisterForm.php:501
+msgid "Submit"
+msgstr ""
+
+#: modules/civiremote_event/src/Form/RegisterForm.php:513
+msgid "Next"
+msgstr ""
+
+#: modules/civiremote_event/src/Form/RegisterForm.php:524
+msgid "Back"
+msgstr ""
+
+#: modules/civiremote_event/src/Form/RegisterForm.php:594;636;649
+msgid "- None -"
+msgstr ""
+
+#: modules/civiremote_event/src/Form/RegisterForm.php:646
+msgid "- Select -"
+msgstr ""
+
+#: modules/civiremote_event/src/Form/RegisterForm.php:1070
 msgid "Registration validation failed, please try again later."
 msgstr ""
 
-#: modules/custom/civiremote/modules/civiremote_event/src/Form/RegistrationCancelForm.php:116
+#: modules/civiremote_event/src/Form/RegistrationCancelForm.php:124
 msgid "Cancel registration for %event_title?"
 msgstr ""
 
-#: modules/custom/civiremote/src/Form/CiviRemoteConfigForm.php:74
+#: src/Form/CiviRemoteConfigForm.php:74
 msgid "CiviMRF Connector"
 msgstr ""
 
-#: modules/custom/civiremote/src/Form/CiviRemoteConfigForm.php:75
+#: src/Form/CiviRemoteConfigForm.php:75
 msgid "The CiviMRF connector to use for connecting to CiviCRM. @cmrf_connectors_link"
 msgstr ""
 
-#: modules/custom/civiremote/src/Form/CiviRemoteConfigForm.php:78
+#: src/Form/CiviRemoteConfigForm.php:78
 msgid "Configure CiviMRF Connectors"
 msgstr ""
 
-#: modules/custom/civiremote/src/Form/CiviRemoteConfigForm.php:89
+#: src/Form/CiviRemoteConfigForm.php:89
 msgid "Acquire CiviRemote ID"
 msgstr ""
 
-#: modules/custom/civiremote/src/Form/CiviRemoteConfigForm.php:90
+#: src/Form/CiviRemoteConfigForm.php:90
 msgid "Whether to match a new user to a CiviCRM contact and store the CiviRemote ID returned by CiviCRM."
 msgstr ""
 
-#: modules/custom/civiremote/src/Form/CiviRemoteConfigForm.php:96
+#: src/Form/CiviRemoteConfigForm.php:96
 msgid "Parameter mapping"
 msgstr ""
 
-#: modules/custom/civiremote/src/Form/CiviRemoteConfigForm.php:97
+#: src/Form/CiviRemoteConfigForm.php:97
 msgid "Acquiring CiviRemote IDs involves matching CiviCRM contacts based on Drupal user data. Configure the mapping between those two."
 msgstr ""
 
-#: modules/custom/civiremote/src/Form/CiviRemoteConfigForm.php:121
+#: src/Form/CiviRemoteConfigForm.php:121
 msgid "Drupal user field"
 msgstr ""
 
-#: modules/custom/civiremote/src/Form/CiviRemoteConfigForm.php:122
+#: src/Form/CiviRemoteConfigForm.php:122
 msgid "CiviCRM contact field"
 msgstr ""
 

--- a/translations/de.po
+++ b/translations/de.po
@@ -26,151 +26,203 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: CiviRemote 1.0\n"
-"POT-Creation-Date: 2021-06-22 11:49+0200\n"
-"PO-Revision-Date: 2021-06-22 12:05+0200\n"
+"POT-Creation-Date: 2023-05-19 15:55+0200\n"
+"PO-Revision-Date: 2023-05-19 15:58+0200\n"
+"Last-Translator: \n"
 "Language-Team: info@systopia.de\n"
+"Language: de_DE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 1.8.7.1\n"
-"Last-Translator: \n"
-"Language: de_DE\n"
+"X-Generator: Poedit 3.0.1\n"
 
-#: modules/custom/civiremote/civiremote.tokens.inc:12
-#: modules/custom/civiremote/civiremote.module:47
+#: civiremote.tokens.inc:12 civiremote.module:50
 msgid "CiviRemote ID"
 msgstr "CiviRemote-ID\t"
 
-#: modules/custom/civiremote/civiremote.tokens.inc:13
-#: modules/custom/civiremote/civiremote.module:48
+#: civiremote.tokens.inc:13 civiremote.module:51
 msgid "The unique CiviRemote ID for the user in the connected CiviCRM."
 msgstr "Die eindeutige CiviRemote-ID für den Benutzer im verbundenen CiviCRM."
 
-#: modules/custom/civiremote/civiremote.info.yml:0
-#: modules/custom/civiremote/civiremote.links.menu.yml:0
+#: civiremote.module:33
+msgid ""
+"Could not complete login. Please try again later or contact the site "
+"administrator."
+msgstr ""
+
+#: civiremote.info.yml:0 civiremote.links.menu.yml:0
+#: config/install/cmrf_core.cmrf_connector.civiremote.yml:0
 msgid "CiviRemote"
 msgstr ""
 
-#: modules/custom/civiremote/civiremote.info.yml:0
+#: civiremote.info.yml:0
 msgid "Core and Tools module for CiviRemote"
 msgstr "Kern- und Werkzeugmodul für CiviRemote"
 
-#: modules/custom/civiremote/civiremote.info.yml:0
-#: modules/custom/civiremote/modules/civiremote_event/civiremote_event.info.yml:0
+#: civiremote.info.yml:0 modules/civiremote_event/civiremote_event.info.yml:0
 msgid "CiviCRM"
 msgstr ""
 
-#: modules/custom/civiremote/civiremote.links.menu.yml:0
+#: civiremote.links.menu.yml:0
 msgid "Configure settings for CiviRemote."
 msgstr "Einstellungen für CiviRemote konfigurieren."
 
-#: modules/custom/civiremote/civiremote.permissions.yml:0
+#: civiremote.permissions.yml:0
 msgid "Administer CiviRemote"
 msgstr "CiviRemote administrieren"
 
-#: modules/custom/civiremote/civiremote.routing.yml:0
+#: civiremote.routing.yml:0
 msgid "CiviRemote Configuration"
 msgstr "CiviRemote-Konfiguration"
 
-#: modules/custom/civiremote/config/schema/civiremote.schema.yml:0
-#: modules/custom/civiremote/src/Plugin/Action/UserMatchContact.php:25
+#: config/schema/civiremote.schema.yml:0
+#: src/Plugin/Action/UserMatchContact.php:25
 msgid "CiviRemote: Match contact(s)"
 msgstr "CiviRemote: Kontakt(e) abgleichen"
 
-#: modules/custom/civiremote/config/schema/civiremote.schema.yml:0
-#: modules/custom/civiremote/src/Plugin/Action/UserSynchroniseRoles.php:24
+#: config/schema/civiremote.schema.yml:0
+#: src/Plugin/Action/UserSynchroniseRoles.php:24
 msgid "CiviRemote: Synchronise CiviRemote roles"
 msgstr "CiviRemote: CiviRemote-Rollen synchronisieren"
 
-#: modules/custom/civiremote/js/dialog.js:0
+#: js/dialog.js:0
 msgid "Close"
 msgstr "Schließen"
 
-#: modules/custom/civiremote/modules/civiremote_event/civiremote_event.info.yml:0;0
-#: modules/custom/civiremote/modules/civiremote_event/civiremote_event.links.menu.yml:0
+#: modules/civiremote_event/civiremote_event.info.yml:0;0
+#: modules/civiremote_event/civiremote_event.links.menu.yml:0
+#: modules/civiremote_event/config/optional/cmrf_views.cmrf_dataset.civiremote_event_events.yml:0
 msgid "CiviRemote Events"
 msgstr ""
 
-#: modules/custom/civiremote/modules/civiremote_event/civiremote_event.links.menu.yml:0
+#: modules/civiremote_event/civiremote_event.links.menu.yml:0
 msgid "Configure settings for CiviRemote Events."
 msgstr "Einstellungen für CiviRemote Events konfigurieren."
 
-#: modules/custom/civiremote/modules/civiremote_event/civiremote_event.routing.yml:0
+#: modules/civiremote_event/civiremote_event.permissions.yml:0
+msgid "Check-in CiviCRM Event Participants"
+msgstr ""
+
+#: modules/civiremote_event/civiremote_event.permissions.yml:0
+msgid ""
+"Grants access to the check-in form for checking in CiviCRM event "
+"participants via CiviRemote."
+msgstr ""
+
+#: modules/civiremote_event/civiremote_event.routing.yml:0
 msgid "CiviRemote Events Configuration"
 msgstr "CiviRemote Events-Konfiguration"
 
-#: modules/custom/civiremote/modules/civiremote_event/config/schema/civiremote_event.schema.yml:0
-#: modules/custom/civiremote/modules/civiremote_event/src/Form/CiviRemoteEventConfigForm.php:42
+#: modules/civiremote_event/config/schema/civiremote_event.schema.yml:0
+#: modules/civiremote_event/src/Form/CiviRemoteEventConfigForm.php:42
 msgid "Profile to form mapping"
 msgstr "Profil-zu-Formular-Zuordnung"
 
-#: modules/custom/civiremote/modules/civiremote_event/config/schema/civiremote_event.schema.yml:0
+#: modules/civiremote_event/config/schema/civiremote_event.schema.yml:0
 msgid "Mapping of a profile ID to a form ID"
 msgstr "Zuordnung einer Profil-ID zu einer Formular-ID"
 
-#: modules/custom/civiremote/modules/civiremote_event/config/schema/civiremote_event.schema.yml:0
+#: modules/civiremote_event/config/schema/civiremote_event.schema.yml:0
 msgid "Profile ID"
 msgstr "Profil-ID"
 
-#: modules/custom/civiremote/modules/civiremote_event/config/schema/civiremote_event.schema.yml:0
+#: modules/civiremote_event/config/schema/civiremote_event.schema.yml:0
 msgid "Form ID"
 msgstr "Formular-ID"
 
-#: modules/custom/civiremote/modules/civiremote_event/config/schema/civiremote_event.schema.yml:0
-#: modules/custom/civiremote/modules/civiremote_event/src/Form/CiviRemoteEventConfigForm.php:126
+#: modules/civiremote_event/config/schema/civiremote_event.schema.yml:0
+#: modules/civiremote_event/src/Form/CiviRemoteEventConfigForm.php:126
 msgid "Form redirect route"
 msgstr "Umleitungs-Route für Formulare"
 
-#: modules/custom/civiremote/modules/civiremote_event/src/CiviMRF.php:67;103
+#: modules/civiremote_event/src/CiviMRF.php:73
 msgid "Could not retrieve remote event."
 msgstr "Entfernte Veranstaltung konnte nicht abgeufen werden."
 
-#: modules/custom/civiremote/modules/civiremote_event/src/CiviMRF.php:148
+#: modules/civiremote_event/src/CiviMRF.php:118
 msgid "Retrieving form failed."
 msgstr "Abrufen des Formulars fehlgeschlagen."
 
-#: modules/custom/civiremote/modules/civiremote_event/src/CiviMRF.php:198
+#: modules/civiremote_event/src/CiviMRF.php:168
 msgid "The event registration validation failed."
 msgstr "Die Validierung der Veranstaltungsanmeldung ist fehlgeschlagen."
 
-#: modules/custom/civiremote/modules/civiremote_event/src/CiviMRF.php:243
+#: modules/civiremote_event/src/CiviMRF.php:213
 msgid "The event registration failed."
 msgstr "Die Veranstaltungsanmeldung ist fehlgeschlagen."
 
-#: modules/custom/civiremote/modules/civiremote_event/src/CiviMRF.php:288
+#: modules/civiremote_event/src/CiviMRF.php:258
 msgid "The event registration update failed."
 msgstr "Die Aktualisierung der Veranstaltungsanmeldung ist fehlgeschlagen."
 
-#: modules/custom/civiremote/modules/civiremote_event/src/CiviMRF.php:328
+#: modules/civiremote_event/src/CiviMRF.php:298
 msgid "The event registration cancellation failed."
 msgstr "Die Stornierung der Veranstaltungsanmeldung ist fehlgeschlagen."
 
-#: modules/custom/civiremote/modules/civiremote_event/src/Form/CiviRemoteEventConfigForm.php:43
+#: modules/civiremote_event/src/CiviMRF.php:343
+msgid "The event checkin verification failed."
+msgstr ""
+
+#: modules/civiremote_event/src/CiviMRF.php:386
+msgid "The event checkin failed."
+msgstr ""
+
+#: modules/civiremote_event/src/Element/Confirm.php:115
+msgid "@fieldTitle (Confirm)"
+msgstr "@fieldTitle (Bestätigung)"
+
+#: modules/civiremote_event/src/Element/Confirm.php:132
+msgid "The confirmation does not match."
+msgstr "Die Bestätigung stimmt nicht überein."
+
+#: modules/civiremote_event/src/Form/CheckinForm.php:125
+msgid "Check-In as %status"
+msgstr ""
+
+#: modules/civiremote_event/src/Form/CheckinForm.php:151;154
+#: modules/civiremote_event/src/Form/RegisterForm.php:859;862
+msgid "Yes"
+msgstr ""
+
+#: modules/civiremote_event/src/Form/CheckinForm.php:151;154
+#: modules/civiremote_event/src/Form/RegisterForm.php:859;862
+msgid "No"
+msgstr ""
+
+#: modules/civiremote_event/src/Form/CheckinForm.php:200
+msgid "Successfully checked-in the participant."
+msgstr ""
+
+#: modules/civiremote_event/src/Form/CheckinForm.php:215
+msgid "Check-in failed, please try again later."
+msgstr ""
+
+#: modules/civiremote_event/src/Form/CiviRemoteEventConfigForm.php:43
 msgid "Define which forms should handle which CiviRemote Events profiles"
 msgstr ""
 "Definieren, welche Formulare welche CiviRemote Events-Profile verarbeiten "
 "sollen"
 
-#: modules/custom/civiremote/modules/civiremote_event/src/Form/CiviRemoteEventConfigForm.php:64
+#: modules/civiremote_event/src/Form/CiviRemoteEventConfigForm.php:64
 msgid "CiviRemote Events profile ID"
 msgstr "CiviRemote Events-Profil-ID"
 
-#: modules/custom/civiremote/modules/civiremote_event/src/Form/CiviRemoteEventConfigForm.php:65
+#: modules/civiremote_event/src/Form/CiviRemoteEventConfigForm.php:65
 msgid "Drupal form ID"
 msgstr "Drupal-Formular-ID"
 
-#: modules/custom/civiremote/modules/civiremote_event/src/Form/CiviRemoteEventConfigForm.php:86
-#: modules/custom/civiremote/src/Form/CiviRemoteConfigForm.php:152
+#: modules/civiremote_event/src/Form/CiviRemoteEventConfigForm.php:86
+#: src/Form/CiviRemoteConfigForm.php:152
 msgid "Remove"
 msgstr "Entfernen"
 
-#: modules/custom/civiremote/modules/civiremote_event/src/Form/CiviRemoteEventConfigForm.php:114
-#: modules/custom/civiremote/src/Form/CiviRemoteConfigForm.php:180
+#: modules/civiremote_event/src/Form/CiviRemoteEventConfigForm.php:114
+#: src/Form/CiviRemoteConfigForm.php:180
 msgid "Add mapping"
 msgstr "Zuordnung hinzufügen"
 
-#: modules/custom/civiremote/modules/civiremote_event/src/Form/CiviRemoteEventConfigForm.php:127
+#: modules/civiremote_event/src/Form/CiviRemoteEventConfigForm.php:127
 msgid ""
 "Enter a Drupal route that should be used as a redirect target after "
 "processing event forms. This will be overridden by a <code>destination</"
@@ -180,72 +232,64 @@ msgstr ""
 "Veranstaltungsformularen verwendet werden soll. Dies wird durch den "
 "Parameter <code>destination</code> in der Formular-URL übersteuert."
 
-#: modules/custom/civiremote/modules/civiremote_event/src/Form/RegisterForm.php:123
+#: modules/civiremote_event/src/Form/RegisterForm.php:124
 msgid "Invalid CiviRemote Event form context"
 msgstr "Ungültiger CiviRemote Event-Formularkontext"
 
-#: modules/custom/civiremote/modules/civiremote_event/src/Form/RegisterForm.php:164
+#: modules/civiremote_event/src/Form/RegisterForm.php:156
 msgid "No profile found for CiviRemote event form."
 msgstr "Kein Profil für CiviRemote-Veranstaltungsformular gefunden."
 
-#: modules/custom/civiremote/modules/civiremote_event/src/Form/RegisterForm.php:539
+#: modules/civiremote_event/src/Form/RegisterForm.php:501
 msgid "Submit"
 msgstr ""
 
-#: modules/custom/civiremote/modules/civiremote_event/src/Form/RegisterForm.php:551
+#: modules/civiremote_event/src/Form/RegisterForm.php:513
 msgid "Next"
 msgstr ""
 
-#: modules/custom/civiremote/modules/civiremote_event/src/Form/RegisterForm.php:562
+#: modules/civiremote_event/src/Form/RegisterForm.php:524
 msgid "Back"
 msgstr ""
 
-#: modules/custom/civiremote/modules/civiremote_event/src/Form/RegisterForm.php:632;677;687
+#: modules/civiremote_event/src/Form/RegisterForm.php:594;636;649
 msgid "- None -"
 msgstr ""
 
-#: modules/custom/civiremote/modules/civiremote_event/src/Form/RegisterForm.php:684
+#: modules/civiremote_event/src/Form/RegisterForm.php:646
 msgid "- Select -"
 msgstr ""
 
-#: modules/custom/civiremote/modules/civiremote_event/src/Form/RegisterForm.php:890;893
-msgid "Yes"
-msgstr ""
-
-#: modules/custom/civiremote/modules/civiremote_event/src/Form/RegisterForm.php:890;893
-msgid "No"
-msgstr ""
-
-#: modules/custom/civiremote/modules/civiremote_event/src/Form/RegisterForm.php:1081
+#: modules/civiremote_event/src/Form/RegisterForm.php:1070
 msgid "Registration validation failed, please try again later."
 msgstr ""
 "Validierung der Anmeldung fehlgeschlagen, bitte versuchen Sie es später "
 "erneut."
 
-#: modules/custom/civiremote/modules/civiremote_event/src/Form/RegistrationCancelForm.php:116
+#: modules/civiremote_event/src/Form/RegistrationCancelForm.php:124
 msgid "Cancel registration for %event_title?"
 msgstr "Anmeldung für %event_title stornieren?"
 
-#: modules/custom/civiremote/src/Form/CiviRemoteConfigForm.php:74
+#: src/Form/CiviRemoteConfigForm.php:74
 msgid "CiviMRF Connector"
 msgstr "CiviMRF-Konnektor"
 
-#: modules/custom/civiremote/src/Form/CiviRemoteConfigForm.php:75
+#: src/Form/CiviRemoteConfigForm.php:75
 msgid ""
 "The CiviMRF connector to use for connecting to CiviCRM. @cmrf_connectors_link"
 msgstr ""
 "Der CiviMRF-Konnektor, der für die Verbindung zu CiviCRM verwendet werden "
 "soll. @cmrf_connectors_link"
 
-#: modules/custom/civiremote/src/Form/CiviRemoteConfigForm.php:78
+#: src/Form/CiviRemoteConfigForm.php:78
 msgid "Configure CiviMRF Connectors"
 msgstr "CiviMRF-Konnektoren konfigurieren"
 
-#: modules/custom/civiremote/src/Form/CiviRemoteConfigForm.php:89
+#: src/Form/CiviRemoteConfigForm.php:89
 msgid "Acquire CiviRemote ID"
 msgstr "CiviRemote-ID abrufen"
 
-#: modules/custom/civiremote/src/Form/CiviRemoteConfigForm.php:90
+#: src/Form/CiviRemoteConfigForm.php:90
 msgid ""
 "Whether to match a new user to a CiviCRM contact and store the CiviRemote ID "
 "returned by CiviCRM."
@@ -253,11 +297,11 @@ msgstr ""
 "Ob neue Benutzer einem CiviCRM-Kontakt zugeordnet und die von CiviCRM "
 "zurückgegebene CiviRemote-ID gespeichert werden soll."
 
-#: modules/custom/civiremote/src/Form/CiviRemoteConfigForm.php:96
+#: src/Form/CiviRemoteConfigForm.php:96
 msgid "Parameter mapping"
 msgstr "Parameter-Zuordnung"
 
-#: modules/custom/civiremote/src/Form/CiviRemoteConfigForm.php:97
+#: src/Form/CiviRemoteConfigForm.php:97
 msgid ""
 "Acquiring CiviRemote IDs involves matching CiviCRM contacts based on Drupal "
 "user data. Configure the mapping between those two."
@@ -266,10 +310,10 @@ msgstr ""
 "Kontakten basierend auf Drupal-Benutzerdaten. Konfigurieren Sie die "
 "Zuordnung zwischen diesen beiden."
 
-#: modules/custom/civiremote/src/Form/CiviRemoteConfigForm.php:121
+#: src/Form/CiviRemoteConfigForm.php:121
 msgid "Drupal user field"
 msgstr "Drupal-Benutzerfeld"
 
-#: modules/custom/civiremote/src/Form/CiviRemoteConfigForm.php:122
+#: src/Form/CiviRemoteConfigForm.php:122
 msgid "CiviCRM contact field"
 msgstr "CiviCRM-Kontaktfeld"


### PR DESCRIPTION
This change requires an update of the translations. How is the pot generated?

systopia-reference: 19785