### PR TITLE
Fix Twig deprecation for 'spaceless' tag

### DIFF
--- a/modules/civiremote_event/templates/cmrf-views-field-json-item--cmrf-views-civiremote-event-events--speakers.html.twig
+++ b/modules/civiremote_event/templates/cmrf-views-field-json-item--cmrf-views-civiremote-event-events--speakers.html.twig
@@ -27,10 +27,10 @@
  * @ingroup themeable
  */
 #}
-{% spaceless %}
+{% apply spaceless %}
     {% for field in item %}
         {% if field.name == 'name' %}
             {{ field.value }}
         {% endif %}
     {% endfor %}
-{% endspaceless %}
+{% endapply %}


### PR DESCRIPTION
This was the deprecation warning from check via module 'upgrade_status':

> The spaceless tag is deprecated since Twig 2.7, use the "spaceless" filter with the "apply" tag instead. See https://drupal.org/node/3071078.