### PR TITLE
Fix definition error in `BaseFieldDefinition` form display for `civiremote_id` field on user entity

### DIFF
--- a/civiremote.module
+++ b/civiremote.module
@@ -56,7 +56,7 @@ function civiremote_entity_base_field_info(EntityTypeInterface $entity_type) {
       ])
       ->setDisplayConfigurable('view', TRUE)
       ->setDisplayOptions('form', [
-        'type' => 'textfield',
+        'type' => 'string_textfield',
         'settings' => [
           'display_label' => TRUE,
         ],


### PR DESCRIPTION
Fixes #5 