### PR TITLE
Dispatch an event for modifying the connector ID

### DIFF
--- a/modules/civiremote_event/src/CiviMRF.php
+++ b/modules/civiremote_event/src/CiviMRF.php
@@ -55,8 +55,7 @@ class CiviMRF extends civiremote\CiviMRF {
 
       $reply = &drupal_static(__FUNCTION__ . '_' . implode('_', $params));
       if (!isset($reply)) {
-        $call = $this->core->createCall(
-          $this->connector(),
+        $call = $this->createCall(
           'RemoteEvent',
           'getsingle',
           $params,
@@ -106,8 +105,7 @@ class CiviMRF extends civiremote\CiviMRF {
 
     $reply = &drupal_static(__FUNCTION__ . '_' . implode('_', $params));
     if (!isset($reply)) {
-      $call = $this->core->createCall(
-        $this->connector(),
+      $call = $this->createCall(
         'RemoteParticipant',
         'get_form',
         $params,
@@ -155,8 +153,7 @@ class CiviMRF extends civiremote\CiviMRF {
       'context' => $context,
     ]);
     self::addRemoteContactId($params);
-    $call = $this->core->createCall(
-      $this->connector(),
+    $call = $this->createCall(
       'RemoteParticipant',
       'validate',
       $params,
@@ -197,8 +194,7 @@ class CiviMRF extends civiremote\CiviMRF {
       'token' => $remote_token
     ]);
     self::addRemoteContactId($params);
-    $call = $this->core->createCall(
-      $this->connector(),
+    $call = $this->createCall(
       'RemoteParticipant',
       'create',
       $params,
@@ -242,8 +238,7 @@ class CiviMRF extends civiremote\CiviMRF {
       'token' => $remote_token
     ]);
     self::addRemoteContactId($params);
-    $call = $this->core->createCall(
-      $this->connector(),
+    $call = $this->createCall(
       'RemoteParticipant',
       'update',
       $params,
@@ -282,8 +277,7 @@ class CiviMRF extends civiremote\CiviMRF {
       'token' => $remote_token
     ];
     self::addRemoteContactId($params);
-    $call = $this->core->createCall(
-      $this->connector(),
+    $call = $this->createCall(
       'RemoteParticipant',
       'cancel',
       $params,
@@ -323,8 +317,7 @@ class CiviMRF extends civiremote\CiviMRF {
         'token' => $remote_token
       ];
       self::addRemoteContactId($params);
-      $call = $this->core->createCall(
-        $this->connector(),
+      $call = $this->createCall(
         'EventCheckin',
         'verify',
         $params,
@@ -370,8 +363,7 @@ class CiviMRF extends civiremote\CiviMRF {
       'status_id' => $status_id,
     ];
     self::addRemoteContactId($params);
-    $call = $this->core->createCall(
-      $this->connector(),
+    $call = $this->createCall(
       'EventCheckin',
       'confirm',
       $params,

--- a/src/CiviMRF.php
+++ b/src/CiviMRF.php
@@ -15,9 +15,10 @@
 
 namespace Drupal\civiremote;
 
-
 use Drupal;
 use Drupal\cmrf_core\Core;
+use Drupal\civiremote\Event\ConnectorEvent;
+use \Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher;
 
 /**
  * Class CiviMRF
@@ -26,15 +27,24 @@ use Drupal\cmrf_core\Core;
  */
 class CiviMRF {
 
-  /** @var Core */
+  /**
+   * @var Core
+   */
   public $core;
 
   public function __construct(Core $core) {
     $this->core = $core;
   }
 
-  protected function connector() {
-    return Drupal::config('civiremote.settings')->get('cmrf_connector');
+  protected function connector(array $context = []) {
+    $event = new ConnectorEvent(
+      Drupal::config('civiremote.settings')->get('cmrf_connector'),
+      $context
+    );
+    /* @var ContainerAwareEventDispatcher $event_dispatcher */
+    $event_dispatcher = \Drupal::service('event_dispatcher');
+    $event_dispatcher->dispatch($event, ConnectorEvent::EVENT_NAME);
+    return $event->getConnectorId();
   }
 
   /**

--- a/src/CiviMRF.php
+++ b/src/CiviMRF.php
@@ -48,14 +48,42 @@ class CiviMRF {
   }
 
   /**
+   * @param $entity
+   * @param $action
+   * @param $params
+   * @param $options
+   * @param $callback
+   * @param $api_version
+   *
+   * @return \CMRF\Core\Call
+   */
+  protected function createCall($entity, $action, $params = [], $options = [], $callback = NULL, $api_version = '3') {
+    return $this->core->createCall(
+      $this->connector([
+        'entity' => $entity,
+        'action' => $action,
+        'params' => $params,
+        'options' => $options,
+        'callback' => $callback,
+        'api_version' => $api_version,
+      ]),
+      $entity,
+      $action,
+      $params,
+      $options,
+      $callback,
+      $api_version
+    );
+  }
+
+  /**
    * @param $params
    *
    * @return string | false
    *   The CiviRemote ID, or FALSE when no contact could be matched.
    */
   public function matchContact($params) {
-    $call = $this->core->createCall(
-      $this->connector(),
+    $call = $this->createCall(
       'RemoteContact',
       'match',
       $params,
@@ -73,8 +101,7 @@ class CiviMRF {
    *   The CiviRemote roles, or FALSE when synchronising roles failed.
    */
   public function getRoles($params) {
-    $call = $this->core->createCall(
-      $this->connector(),
+    $call = $this->createCall(
       'RemoteContact',
       'get_roles',
       $params,

--- a/src/Event/ConnectorEvent.php
+++ b/src/Event/ConnectorEvent.php
@@ -34,4 +34,13 @@ class ConnectorEvent extends Event {
     return $this->connector_id;
   }
 
+  /**
+   * @param string $connector_id
+   *
+   * @return void
+   */
+  public function setConnectorId(string $connector_id): void {
+    $this->connector_id = $connector_id;
+  }
+
 }

--- a/src/Event/ConnectorEvent.php
+++ b/src/Event/ConnectorEvent.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\civiremote\Event;
+
+use Drupal\Component\EventDispatcher\Event;
+
+class ConnectorEvent extends Event {
+
+  const EVENT_NAME = 'civiremote_connector';
+
+  /**
+   * The CiviMRF Connector ID.
+   *
+   * @var string $connector_id
+   */
+  protected string $connector_id;
+
+  /**
+   * The context of the event.
+   *
+   * @var array $context
+   */
+  protected array $context;
+
+  public function __construct(string $connector_id, array $context = []) {
+    $this->connector_id = $connector_id;
+    $this->context = $context;
+  }
+
+  /**
+   * @return string
+   */
+  public function getConnectorId(): string {
+    return $this->connector_id;
+  }
+
+}


### PR DESCRIPTION
For displaying events (or in general: *CiviRemote* entities) from multiple CiviCRM instances, the `civiremote_connector_id` needs to be modifiable, as there's only a configuration option fpr one single connector entity.

This adds an event being dispatched when *CiviRemote* fetches the connector before querying the CiviCRM API, so that implementers may alter the default connector depending on context. Currently, context includes:

```php
[
  'entity' => $entity,
  'action' => $action,
  'params' => $params,
  'options' => $options,
  'callback' => $callback,
  'api_version' => $api_version,
]
```