### PR TITLE
Fix conditions for deciding whether "Select" fields are to be displayed as radio buttons or checkboxes

### DIFF
--- a/modules/civiremote_event/src/Utils.php
+++ b/modules/civiremote_event/src/Utils.php
@@ -42,14 +42,23 @@ class Utils {
     if (isset($field['validation']) && $field['validation'] == 'Email') {
       $type = 'email';
     }
-    // Use radio buttons for select fields with up to 10 options.
+    // Use checkboxes for multi-select fields with up to 10 options.
     elseif (
       $types[$field['type']] == 'select'
       && count($field['options']) <= 10
       // Checkboxes #options may not have a 0 key.
       && !isset($field['options'][0])
+      && $field['type'] == 'Multi-Select'
     ) {
-      $type = $field['type'] == 'Multi-Select' ? 'checkboxes' : 'radios';
+      $type = 'checkboxes';
+    }
+    // Use radio buttons for single-select fields with up to 10 options.
+    elseif (
+      $types[$field['type']] == 'select'
+      && count($field['options']) <= 10
+      && $field['type'] != 'Multi-Select'
+    ) {
+      $type = 'radios';
     }
     // Use details element for session fieldsets.
     elseif (


### PR DESCRIPTION
*systopia-reference: 22443*

3caa58fca2e73f8d733680336637af1ebc39d6b1 introduced a condition for select fields not to display as checkboxes when there's an option with the `0` key, as this leads to issues with Drupal's validation of checkbox values. Unfortunately, this condition also applies to multi-value select fields that are supposed to be displayed as radio buttons, which aren't affected by the `0`-key problem.

This PR fixes conditions accordingly.