### PR TITLE
Retrieve cancellation form also when not using tokens

### DIFF
--- a/modules/civiremote_event/src/Form/RegistrationCancelForm.php
+++ b/modules/civiremote_event/src/Form/RegistrationCancelForm.php
@@ -78,28 +78,27 @@ class RegistrationCancelForm extends ConfirmFormBase {
     $routeMatch = RouteMatch::createFromRequest($this->getRequest());
     $this->event = $routeMatch->getParameter('event');
     $this->remote_token = $routeMatch->getRawParameter('event_token');
-    // Retrieve event using the remote token, overwriting the event object.
-    if (!empty($this->remote_token)) {
-      try {
-        $form = $this->cmrf->getForm(
-          (isset($this->event) ? $this->event->id : NULL),
-          NULL,
-          $this->remote_token,
-          'cancel'
-        );
-        $this->fields = $form['values'];
-        $this->messages = isset($form['status_messages']) ? $form['status_messages'] : [];
+    try {
+      $form = $this->cmrf->getForm(
+        (isset($this->event) ? $this->event->id : NULL),
+        NULL,
+        $this->remote_token,
+        'cancel'
+      );
+      $this->fields = $form['values'];
+      $this->messages = isset($form['status_messages']) ? $form['status_messages'] : [];
+      if (!$this->event) {
         $this->event = $this->cmrf->getEvent(
           $this->fields['event_id']['value'],
           $this->remote_token
         );
       }
-      catch (Exception $exception) {
-        Drupal::messenger()->addMessage(
-          $exception->getMessage(),
-          MessengerInterface::TYPE_ERROR
-        );
-      }
+    }
+    catch (Exception $exception) {
+      Drupal::messenger()->addMessage(
+        $exception->getMessage(),
+        MessengerInterface::TYPE_ERROR
+      );
     }
   }
 


### PR DESCRIPTION
This seems to have been implemented incorrectly in the first place …