### PR TITLE
Move form definition retrieval out of controller constructors for proper access checking in other contexts

### DIFF
--- a/modules/civiremote_event/civiremote_event.routing.yml
+++ b/modules/civiremote_event/civiremote_event.routing.yml
@@ -13,8 +13,9 @@ civiremote_event.register_form:
     _title_callback: '\Drupal\civiremote_event\Controller\RegisterFormController::title'
     # The profile is optional.
     profile: null
+    context: 'create'
   requirements:
-    _custom_access: '\Drupal\civiremote_event\Form\RegisterForm::access'
+    _custom_access: '\Drupal\civiremote_event\Controller\RegisterFormController::access'
   options:
     no_cache: TRUE
     parameters:
@@ -22,64 +23,82 @@ civiremote_event.register_form:
         type: civiremote_event
       profile:
         type: string
+      context:
+        type: string
 civiremote_event.register_token_form:
   path: '/civiremote/event/register/{event_token}'
   defaults:
     _controller: '\Drupal\civiremote_event\Controller\RegisterFormController::form'
     _title_callback: '\Drupal\civiremote_event\Controller\RegisterFormController::title'
+    context: create
   requirements:
-    _custom_access: '\Drupal\civiremote_event\Form\RegisterForm::access'
+    _custom_access: '\Drupal\civiremote_event\Controller\RegisterFormController::access'
   options:
     no_cache: TRUE
     parameters:
       event_token:
         type: civiremote_event_token
+      context:
+        type: string
 
 civiremote_event.registration_cancel_form:
   path: '/civiremote/event/{event}/cancel'
   defaults:
-    _form: '\Drupal\civiremote_event\Form\RegistrationCancelForm'
+    _controller: '\Drupal\civiremote_event\Controller\RegisterFormController::form'
+    context: 'cancel'
   requirements:
-    _custom_access: '\Drupal\civiremote_event\Form\RegistrationCancelForm::access'
+    _custom_access: '\Drupal\civiremote_event\Controller\RegisterFormController::access'
   options:
     no_cache: TRUE
     parameters:
       event:
         type: civiremote_event
+      context:
+        type: string
 civiremote_event.registration_cancel_token_form:
   path: '/civiremote/event/cancel/{event_token}'
   defaults:
-    _form: '\Drupal\civiremote_event\Form\RegistrationCancelForm'
+    _controller: '\Drupal\civiremote_event\Controller\RegisterFormController::form'
+    context: 'cancel'
   requirements:
-    _custom_access: '\Drupal\civiremote_event\Form\RegistrationCancelForm::access'
+    _custom_access: '\Drupal\civiremote_event\Controller\RegisterFormController::access'
   options:
     no_cache: TRUE
     parameters:
       event_token:
         type: civiremote_event_token
+      context: string
 
 civiremote_event.registration_update_form:
   path: '/civiremote/event/{event}/update'
   defaults:
-    _form: '\Drupal\civiremote_event\Form\RegistrationUpdateForm'
+    _controller: '\Drupal\civiremote_event\Controller\RegisterFormController::form'
+    _title_callback: '\Drupal\civiremote_event\Controller\RegisterFormController::title'
+    context: 'update'
   requirements:
-    _custom_access: '\Drupal\civiremote_event\Form\RegistrationUpdateForm::access'
+    _custom_access: '\Drupal\civiremote_event\Controller\RegisterFormController::access'
   options:
     no_cache: TRUE
     parameters:
       event:
         type: civiremote_event
+      context:
+        type: string
 civiremote_event.registration_update_token_form:
   path: '/civiremote/event/update/{event_token}'
   defaults:
-    _form: '\Drupal\civiremote_event\Form\RegistrationUpdateForm'
+    _controller: '\Drupal\civiremote_event\Controller\RegisterFormController::form'
+    _title_callback: '\Drupal\civiremote_event\Controller\RegisterFormController::title'
+    context: 'update'
   requirements:
-    _custom_access: '\Drupal\civiremote_event\Form\RegistrationUpdateForm::access'
+    _custom_access: '\Drupal\civiremote_event\Controller\RegisterFormController::access'
   options:
     no_cache: TRUE
     parameters:
       event_token:
         type: civiremote_event_token
+      context:
+        type: string
 
 civiremote_event.checkin_form:
   path: '/civiremote/event/checkin/{checkin_token}'

--- a/modules/civiremote_event/civiremote_event.routing.yml
+++ b/modules/civiremote_event/civiremote_event.routing.yml
@@ -28,11 +28,11 @@ civiremote_event.register_form:
 civiremote_event.register_token_form:
   path: '/civiremote/event/register/{event_token}'
   defaults:
-    _controller: '\Drupal\civiremote_event\Controller\RegisterFormController::form'
-    _title_callback: '\Drupal\civiremote_event\Controller\RegisterFormController::title'
+    _controller: '\Drupal\civiremote_event\Controller\RegisterFormController::formWithToken'
+    _title_callback: '\Drupal\civiremote_event\Controller\RegisterFormController::titleWithToken'
     context: create
   requirements:
-    _custom_access: '\Drupal\civiremote_event\Controller\RegisterFormController::access'
+    _custom_access: '\Drupal\civiremote_event\Controller\RegisterFormController::accessWithToken'
   options:
     no_cache: TRUE
     parameters:
@@ -58,10 +58,10 @@ civiremote_event.registration_cancel_form:
 civiremote_event.registration_cancel_token_form:
   path: '/civiremote/event/cancel/{event_token}'
   defaults:
-    _controller: '\Drupal\civiremote_event\Controller\RegisterFormController::form'
+    _controller: '\Drupal\civiremote_event\Controller\RegisterFormController::formWithToken'
     context: 'cancel'
   requirements:
-    _custom_access: '\Drupal\civiremote_event\Controller\RegisterFormController::access'
+    _custom_access: '\Drupal\civiremote_event\Controller\RegisterFormController::accessWithToken'
   options:
     no_cache: TRUE
     parameters:
@@ -87,11 +87,11 @@ civiremote_event.registration_update_form:
 civiremote_event.registration_update_token_form:
   path: '/civiremote/event/update/{event_token}'
   defaults:
-    _controller: '\Drupal\civiremote_event\Controller\RegisterFormController::form'
-    _title_callback: '\Drupal\civiremote_event\Controller\RegisterFormController::title'
+    _controller: '\Drupal\civiremote_event\Controller\RegisterFormController::formWithToken'
+    _title_callback: '\Drupal\civiremote_event\Controller\RegisterFormController::titleWithToken'
     context: 'update'
   requirements:
-    _custom_access: '\Drupal\civiremote_event\Controller\RegisterFormController::access'
+    _custom_access: '\Drupal\civiremote_event\Controller\RegisterFormController::accessWithToken'
   options:
     no_cache: TRUE
     parameters:

--- a/modules/civiremote_event/src/Controller/RegisterFormController.php
+++ b/modules/civiremote_event/src/Controller/RegisterFormController.php
@@ -30,11 +30,11 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class RegisterFormController extends ControllerBase {
 
-  const CONTEXT_CREATE = 'create';
+  public const CONTEXT_CREATE = 'create';
 
-  const CONTEXT_UPDATE = 'update';
+  public const CONTEXT_UPDATE = 'update';
 
-  const CONTEXT_CANCEL = 'cancel';
+  public const CONTEXT_CANCEL = 'cancel';
 
   /**
    * @var CiviMRF $cmrf
@@ -64,9 +64,7 @@ class RegisterFormController extends ControllerBase {
      * @var CiviMRF $cmrf
      */
     $cmrf = $container->get('civiremote_event.cmrf');
-    return new static(
-      $cmrf
-    );
+    return new static($cmrf);
   }
 
   /**

--- a/modules/civiremote_event/src/Form/RegistrationUpdateForm.php
+++ b/modules/civiremote_event/src/Form/RegistrationUpdateForm.php
@@ -107,35 +107,4 @@ class RegistrationUpdateForm extends RegisterForm {
     }
   }
 
-  /**
-   * Custom access callback for this form's route.
-   *
-   * Note: The parameters passed in here are not being used, since they have
-   * been processed in the constructor already. Instead, class members are being
-   * used for deciding about access.
-   *
-   * @param stdClass $event
-   *   The remote event retrieved by the RemoteEvent.get API.
-   * @param string $profile
-   *   The remote event profile to use for displaying the form.
-   * @param string $remote_token
-   *   The remote token to use for retrieving the form.
-   *
-   * @return AccessResult|AccessResultAllowed|AccessResultNeutral
-   */
-  public function access(stdClass $event = NULL, $profile = NULL, $remote_token = NULL) {
-    // Grant access depending on flags on the remote event.
-    return AccessResult::allowedIf(
-      !empty($this->event)
-      && $this->event->can_edit_registration
-      && (
-        !isset($this->profile)
-        || in_array(
-          $this->profile,
-          explode(',', $this->event->enabled_update_profiles)
-        )
-      )
-    );
-  }
-
 }


### PR DESCRIPTION
Fixes #14. Replaces #15.

This is a more comprehensive approach to moving form definition retrieval out of controller constructors.

The `\Drupal\civiremote_event\Controller\RegisterFormController` class now responds to all registration-related routes (register, update, cancel) and includes a combined access check that can be used reliably outside of those route contexts (e.g. when validating a URL for displaying on another page).

Also, retrieving the form definition is now done in a centralized controller method before handing things off to the respective form builders, which do not have to care for initializing things in their constructor anymore. This also prevents intermittent error messages be displayed for errors during route access checks.

@FeyP Would you be able to give this a try and leave a review?