### PR TITLE
Require `drupal/cmrf_core` 2.1 for APIv4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,9 @@
     "homepage": "https://github.com/systopia/civiremote",
     "require": {
         "beberlei/assert": "*",
-        "drupal/cmrf_core": "^1.0@beta | ^2.0@beta"
+        "drupal/cmrf_core": "^2.1@beta"
+    },
+    "conflict": {
+        "drupal/cmrf_core": "2.1.0-beta5"
     }
 }

--- a/modules/civiremote_activity/ci/composer.json
+++ b/modules/civiremote_activity/ci/composer.json
@@ -10,14 +10,6 @@
             "url": "https://github.com/systopia/drupal-json_forms.git"
         },
         {
-            "type": "vcs",
-            "url": "https://github.com/systopia/opis-json-schema-ext.git"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/systopia/expression-language-ext.git"
-        },
-        {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
         }

--- a/modules/civiremote_entity/ci/composer.json
+++ b/modules/civiremote_entity/ci/composer.json
@@ -11,7 +11,10 @@
         }
     ],
     "require": {
-        "drupal/cmrf_core": "^2.0",
+        "drupal/cmrf_core": "^2.1",
         "drupal/core": "^9.5 || ^10"
+    },
+    "conflict": {
+        "drupal/cmrf_core": "2.1.0-beta5"
     }
 }

--- a/modules/civiremote_entity/composer.json
+++ b/modules/civiremote_entity/composer.json
@@ -34,14 +34,6 @@
             "url": "https://github.com/systopia/drupal-json_forms.git"
         },
         {
-            "type": "vcs",
-            "url": "https://github.com/systopia/opis-json-schema-ext.git"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/systopia/expression-language-ext.git"
-        },
-        {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
         }


### PR DESCRIPTION
`drupal/cmrf_core` `2.1.0-beta5` is marked as conflict because it is wrongly tagged.