### PR TITLE
Allow profile parameter for token-based forms

### DIFF
--- a/modules/civiremote_event/civiremote_event.routing.yml
+++ b/modules/civiremote_event/civiremote_event.routing.yml
@@ -26,11 +26,13 @@ civiremote_event.register_form:
       context:
         type: string
 civiremote_event.register_token_form:
-  path: '/civiremote/event/register/{event_token}'
+  path: '/civiremote/event/register/{event_token}/{profile}'
   defaults:
     _controller: '\Drupal\civiremote_event\Controller\RegisterFormController::formWithToken'
     _title_callback: '\Drupal\civiremote_event\Controller\RegisterFormController::titleWithToken'
-    context: create
+    # The profile is optional.
+    profile: null
+    context: 'create'
   requirements:
     _custom_access: '\Drupal\civiremote_event\Controller\RegisterFormController::accessWithToken'
   options:
@@ -38,6 +40,8 @@ civiremote_event.register_token_form:
     parameters:
       event_token:
         type: civiremote_event_token
+      profile:
+        type: string
       context:
         type: string
 
@@ -70,10 +74,12 @@ civiremote_event.registration_cancel_token_form:
       context: string
 
 civiremote_event.registration_update_form:
-  path: '/civiremote/event/{event}/update'
+  path: '/civiremote/event/{event}/update/{profile}'
   defaults:
     _controller: '\Drupal\civiremote_event\Controller\RegisterFormController::form'
     _title_callback: '\Drupal\civiremote_event\Controller\RegisterFormController::title'
+    # The profile is optional.
+    profile: null
     context: 'update'
   requirements:
     _custom_access: '\Drupal\civiremote_event\Controller\RegisterFormController::access'
@@ -82,13 +88,17 @@ civiremote_event.registration_update_form:
     parameters:
       event:
         type: civiremote_event
+      profile:
+        type: string
       context:
         type: string
 civiremote_event.registration_update_token_form:
-  path: '/civiremote/event/update/{event_token}'
+  path: '/civiremote/event/update/{event_token}/{profile}'
   defaults:
     _controller: '\Drupal\civiremote_event\Controller\RegisterFormController::formWithToken'
     _title_callback: '\Drupal\civiremote_event\Controller\RegisterFormController::titleWithToken'
+    # The profile is optional.
+    profile: null
     context: 'update'
   requirements:
     _custom_access: '\Drupal\civiremote_event\Controller\RegisterFormController::accessWithToken'
@@ -97,6 +107,8 @@ civiremote_event.registration_update_token_form:
     parameters:
       event_token:
         type: civiremote_event_token
+      profile:
+        type: string
       context:
         type: string
 

--- a/modules/civiremote_event/src/Controller/RegisterFormController.php
+++ b/modules/civiremote_event/src/Controller/RegisterFormController.php
@@ -77,12 +77,13 @@ class RegisterFormController extends ControllerBase {
    *
    * @see \Drupal\civiremote_event\Routing\EventTokenConverter
    */
-  public function formWithToken(RouteMatch $route_match, string $context, stdClass $event_token) {
+  public function formWithToken(RouteMatch $route_match, string $context, stdClass $event_token, string $profile = NULL) {
     return self::form(
       $route_match,
       $context,
       $event_token,
-      $route_match->getRawParameter('event_token')
+      $route_match->getRawParameter('event_token'),
+      $profile
     );
   }
 
@@ -90,7 +91,7 @@ class RegisterFormController extends ControllerBase {
     // Retrieve the form definition.
     try {
       $form = $this->cmrf->getForm(
-        (isset($event) ? $event->id : NULL),
+        $event->id,
         $profile,
         $raw_event_token,
         $context
@@ -116,11 +117,12 @@ class RegisterFormController extends ControllerBase {
         }
       }
     }
-    catch (Exception $exception) {
+    catch (\Exception $exception) {
       Drupal::messenger()->addMessage(
         $exception->getMessage(),
         MessengerInterface::TYPE_ERROR
       );
+      return [];
     }
 
     // Retrieve implementation for building the form.


### PR DESCRIPTION
Update forms and forms with a token currently can't receive a profile. This PR adds this ability. The API seems to support this already.