### PR TITLE
Add code to access remote `Case` entity

### DIFF
--- a/.github/workflows/phpcs_case.yml
+++ b/.github/workflows/phpcs_case.yml
@@ -1,0 +1,45 @@
+name: PHP_CodeSniffer - civiremote_case
+
+on:
+  pull_request:
+    paths:
+      - 'modules/civiremote_case/src/**.php'
+      - modules/civiremote_case/composer.json
+      - modules/civiremote_case/phpcs.xml.dist
+
+jobs:
+  phpcs:
+    runs-on: ubuntu-latest
+    name: PHP_CodeSniffer
+    defaults:
+      run:
+        working-directory: modules/civiremote_case
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.3
+          coverage: none
+          tools: cs2pr
+        env:
+          fail-fast: true
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('modules/civiremote_case/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer update --no-progress --prefer-dist
+
+      - name: Run PHP_CodeSniffer
+        run: composer phpcs -- -q --report=checkstyle | cs2pr

--- a/.github/workflows/phpstan_case.yml
+++ b/.github/workflows/phpstan_case.yml
@@ -1,0 +1,55 @@
+name: PHPStan - civiremote_case
+
+on:
+  pull_request:
+    paths:
+      - 'modules/civiremote_case/src/**.php'
+      - modules/civiremote_case/composer.json
+      - modules/civiremote_case/tools/phpstan/composer.json
+      - modules/civiremote_case/ci/composer.json
+      - modules/civiremote_case/phpstan.ci.neon
+      - modules/civiremote_case/phpstan.neon.dist
+      - 'modules/civiremote_entity/src/**.php'
+
+jobs:
+  phpstan:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-versions: ['8.1', '8.3']
+        prefer: ['prefer-stable', 'prefer-lowest']
+    name: PHPStan with PHP ${{ matrix.php-versions }} ${{ matrix.prefer }}
+    defaults:
+      run:
+        working-directory: modules/civiremote_case
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          coverage: none
+        env:
+          fail-fast: true
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ matrix.prefer }}-${{ hashFiles('modules/civiremote_case/**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-${{ matrix.prefer }}-
+
+      - name: Install dependencies
+        run: |
+          composer update --no-progress --prefer-dist --${{ matrix.prefer }} --optimize-autoloader &&
+          composer composer-phpstan -- update --no-progress --prefer-dist --optimize-autoloader &&
+          composer --working-dir=ci update --no-progress --prefer-dist --${{ matrix.prefer }} --optimize-autoloader
+
+      - name: Run PHPStan
+        run: composer phpstan -- analyse -c phpstan.ci.neon

--- a/modules/civiremote_case/ci/README.md
+++ b/modules/civiremote_case/ci/README.md
@@ -1,0 +1,2 @@
+The dependencies specified in composer.json of this directory are required to
+run phpstan in CI.

--- a/modules/civiremote_case/ci/composer.json
+++ b/modules/civiremote_case/ci/composer.json
@@ -1,0 +1,21 @@
+{
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "config": {
+        "sort-packages": true
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/systopia/drupal-json_forms.git"
+        },
+        {
+            "type": "composer",
+            "url": "https://packages.drupal.org/8"
+        }
+    ],
+    "require": {
+        "drupal/core": "^10",
+        "drupal/json_forms": "~0.1"
+    }
+}

--- a/modules/civiremote_case/civiremote_case.info.yml
+++ b/modules/civiremote_case/civiremote_case.info.yml
@@ -1,0 +1,10 @@
+name: CiviRemote Case
+type: module
+description: 'CiviRemote Case'
+package: CiviCRM
+core_version_requirement: ^10
+dependencies:
+  - civiremote_entity
+
+project: civiremote
+version: 1.1.x-dev

--- a/modules/civiremote_case/civiremote_case.permissions.yml
+++ b/modules/civiremote_case/civiremote_case.permissions.yml
@@ -1,0 +1,2 @@
+access civiremote case:
+  title: 'Access Cases in CiviCRM'

--- a/modules/civiremote_case/civiremote_case.routing.yml
+++ b/modules/civiremote_case/civiremote_case.routing.yml
@@ -1,0 +1,25 @@
+civiremote_case.create_form:
+  path: '/civiremote/case/add/{profile}'
+  defaults:
+    _controller: 'Drupal\civiremote_case\Controller\CaseCreateController::form'
+  options:
+    no_cache: TRUE
+    parameters:
+      profile:
+        type: string
+  requirements:
+    _user_is_logged_in: 'TRUE'
+
+civiremote_case.update_form:
+  path: '/civiremote/case/{id}/update/{profile}'
+  defaults:
+    _controller: 'Drupal\civiremote_case\Controller\CaseUpdateController::form'
+  options:
+    no_cache: TRUE
+    parameters:
+      id:
+        type: int
+      profile:
+        type: string
+  requirements:
+    _user_is_logged_in: 'TRUE'

--- a/modules/civiremote_case/civiremote_case.routing.yml
+++ b/modules/civiremote_case/civiremote_case.routing.yml
@@ -8,7 +8,7 @@ civiremote_case.create_form:
       profile:
         type: string
   requirements:
-    _user_is_logged_in: 'TRUE'
+    _permission: 'access civiremote case'
 
 civiremote_case.update_form:
   path: '/civiremote/case/{id}/update/{profile}'
@@ -22,4 +22,4 @@ civiremote_case.update_form:
       profile:
         type: string
   requirements:
-    _user_is_logged_in: 'TRUE'
+    _permission: 'access civiremote case'

--- a/modules/civiremote_case/civiremote_case.services.yml
+++ b/modules/civiremote_case/civiremote_case.services.yml
@@ -1,0 +1,23 @@
+services:
+  _defaults:
+    autowire: true
+    public: false # Controller classes and services directly fetched from container need to be public
+
+  Drupal\civiremote_case\Api\CaseApi:
+    class: Drupal\civiremote_case\Api\CaseApi
+
+  Drupal\civiremote_case\Controller\CaseCreateController:
+    class: Drupal\civiremote_case\Controller\CaseCreateController
+    public: true
+
+  Drupal\civiremote_case\Controller\CaseUpdateController:
+    class: Drupal\civiremote_case\Controller\CaseUpdateController
+    public: true
+
+  Drupal\civiremote_case\Form\RequestHandler\CaseCreateFormRequestHandler:
+    class: Drupal\civiremote_case\Form\RequestHandler\CaseCreateFormRequestHandler
+    public: true
+
+  Drupal\civiremote_case\Form\RequestHandler\CaseUpdateFormRequestHandler:
+    class: Drupal\civiremote_case\Form\RequestHandler\CaseUpdateFormRequestHandler
+    public: true

--- a/modules/civiremote_case/composer.json
+++ b/modules/civiremote_case/composer.json
@@ -1,0 +1,69 @@
+{
+    "name": "custom/civiremote_case",
+    "description": "Drupal frontend to access CiviCRM Remote Case.",
+    "type": "drupal-custom-module",
+    "license": "AGPL-3.0-only",
+    "authors": [
+        {
+            "name": "SYSTOPIA GmbH",
+            "email": "info@systopia.de"
+        }
+    ],
+    "autoload": {
+        "psr-4": {
+            "Drupal\\civiremote_case\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Drupal\\Tests\\civiremote_case\\": "tests/src/"
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "config": {
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "phpstan/extension-installer": true,
+            "php-http/discovery": false
+        }
+    },
+    "repositories": [
+        {
+            "type": "composer",
+            "url": "https://packages.drupal.org/8"
+        }
+    ],
+    "require": {
+        "php": "^8.1"
+    },
+    "require-dev": {
+        "drupal/core-dev": "^10"
+    },
+    "scripts": {
+        "composer-phpstan": [
+            "@composer --working-dir=tools/phpstan"
+        ],
+        "composer-tools": [
+            "@composer-phpstan"
+        ],
+        "phpcs": [
+            "@php vendor/bin/phpcs"
+        ],
+        "phpcbf": [
+            "@php vendor/bin/phpcbf"
+        ],
+        "phpstan": [
+            "@php tools/phpstan/vendor/bin/phpstan"
+        ],
+        "phpunit": [
+            "@php vendor/bin/phpunit --coverage-text"
+        ],
+        "test": [
+            "@phpcs",
+            "@phpstan",
+            "@phpunit"
+        ]
+    }
+}

--- a/modules/civiremote_case/phpcs.xml.dist
+++ b/modules/civiremote_case/phpcs.xml.dist
@@ -1,0 +1,80 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="CiviCRM - PHPStan"
+         xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
+
+  <file>src</file>
+
+  <arg name="extensions" value="php"/>
+  <arg name="cache" value=".phpcs.cache"/>
+  <arg name="colors"/>
+  <arg value="sp"/>
+
+  <!-- Exit with code 0 if warnings, but no error occurred -->
+  <config name="ignore_warnings_on_exit" value="true"/>
+
+  <rule ref="vendor/drupal/coder/coder_sniffer/Drupal">
+    <!-- Don't enforce phpdoc type hint because it (might) only duplicate a PHP type hint -->
+    <exclude name="Drupal.Commenting.FunctionComment.MissingParamComment"/>
+    <exclude name="Drupal.Commenting.FunctionComment.MissingReturnComment"/>
+
+    <!-- Don't enforce comments -->
+    <exclude name="Drupal.Commenting.VariableComment.Missing"/>
+    <exclude name="Drupal.Commenting.ClassComment.Missing"/>
+    <exclude name="Drupal.Commenting.FunctionComment.Missing"/>
+    <exclude name="Drupal.Commenting.DocComment.MissingShort"/>
+
+    <!-- Allow "/** @phpstan-var ... */" -->
+    <exclude name="Drupal.Commenting.InlineComment.DocBlock"/>
+
+    <!-- False positive with license header -->
+    <exclude name="Drupal.Commenting.FileComment.NamespaceNoFileDoc"/>
+  </rule>
+
+  <rule ref="vendor/drupal/coder/coder_sniffer/DrupalPractice"/>
+
+  <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
+  <rule ref="Generic.CodeAnalysis.EmptyStatement">
+    <exclude name="Generic.CodeAnalysis.EmptyStatement.DetectedCatch"/>
+  </rule>
+  <rule ref="Generic.CodeAnalysis.ForLoopWithTestFunctionCall"/>
+  <rule ref="Generic.Files.OneClassPerFile"/>
+  <rule ref="Generic.Files.OneInterfacePerFile"/>
+  <rule ref="Generic.Files.OneObjectStructurePerFile"/>
+  <rule ref="Generic.Files.OneTraitPerFile"/>
+  <rule ref="Generic.Formatting.DisallowMultipleStatements"/>
+  <rule ref="Generic.Metrics.CyclomaticComplexity"/>
+  <rule ref="Generic.Metrics.NestingLevel"/>
+  <rule ref="Generic.NamingConventions.AbstractClassNamePrefix"/>
+  <rule ref="Generic.NamingConventions.InterfaceNameSuffix"/>
+  <rule ref="Generic.NamingConventions.TraitNameSuffix"/>
+  <rule ref="Generic.PHP.RequireStrictTypes"/>
+  <rule ref="PSR1.Files.SideEffects"/>
+  <rule ref="PSR12.Classes.ClassInstantiation"/>
+  <rule ref="PSR12.Properties.ConstantVisibility"/>
+  <rule ref="Squiz.PHP.CommentedOutCode"/>
+  <rule ref="Squiz.PHP.GlobalKeyword"/>
+  <rule ref="Squiz.Strings.DoubleQuoteUsage">
+    <exclude name="Squiz.Strings.DoubleQuoteUsage.ContainsVar"/>
+  </rule>
+
+  <!-- Lines can be 120 chars long, but never show errors -->
+  <rule ref="Generic.Files.LineLength">
+    <properties>
+      <property name="lineLimit" value="120"/>
+      <property name="absoluteLineLimit" value="0"/>
+    </properties>
+  </rule>
+
+  <!-- Ban some functions -->
+  <rule ref="Generic.PHP.ForbiddenFunctions">
+    <properties>
+      <property name="forbiddenFunctions" type="array">
+        <element key="sizeof" value="count"/>
+        <element key="delete" value="unset"/>
+        <element key="print" value="echo"/>
+        <element key="is_null" value="null"/>
+        <element key="create_function" value="null"/>
+      </property>
+    </properties>
+  </rule>
+</ruleset>

--- a/modules/civiremote_case/phpstan.ci.neon
+++ b/modules/civiremote_case/phpstan.ci.neon
@@ -1,0 +1,6 @@
+includes:
+	- phpstan.neon.dist
+
+parameters:
+	bootstrapFiles:
+		- ci/vendor/autoload.php

--- a/modules/civiremote_case/phpstan.neon.dist
+++ b/modules/civiremote_case/phpstan.neon.dist
@@ -1,0 +1,26 @@
+parameters:
+	paths:
+		- src
+	bootstrapFiles:
+		- vendor/autoload.php
+	scanDirectories:
+		- ../civiremote_entity/src
+	level: 9
+	checkTooWideReturnTypesInProtectedAndPublicMethods: true
+	checkUninitializedProperties: true
+	checkMissingCallableSignature: true
+	treatPhpDocTypesAsCertain: false
+	exceptions:
+		check:
+			missingCheckedExceptionInThrows: true
+			tooWideThrowType: true
+		checkedExceptionClasses:
+			- \Assert\AssertionFailedException
+		implicitThrows: false
+	ignoreErrors:
+		# Note paths are prefixed with ""*/" to work with inspections in PHPStorm because of:
+		# https://youtrack.jetbrains.com/issue/WI-63891/PHPStan-ignoreErrors-configuration-isnt-working-with-inspections
+		# Happens in classes implementing ContainerInjectionInterface::create()
+		- '/ constructor expects [^\s]+, object(\|null)? given.$/'
+
+	tmpDir: .phpstan

--- a/modules/civiremote_case/phpstan.neon.template
+++ b/modules/civiremote_case/phpstan.neon.template
@@ -1,0 +1,9 @@
+# Copy this file to phpstan.neon and replace {VENDOR_DIR} with the vendor
+# directory of your Drupal project.
+
+includes:
+	- phpstan.neon.dist
+
+parameters:
+	bootstrapFiles:
+		- {VENDOR_DIR}/autoload.php

--- a/modules/civiremote_case/phpunit.xml.dist
+++ b/modules/civiremote_case/phpunit.xml.dist
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- For how to customize PHPUnit configuration, see core/tests/README.md. -->
+<!-- PHPUnit expects functional tests to be run with either a privileged user
+ or your current system user. See core/tests/README.md and
+ https://www.drupal.org/node/2116263 for details.
+-->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
+         bootstrap="../../../core/tests/bootstrap.php"
+         colors="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutChangesToGlobalState="true"
+         forceCoversAnnotation="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         printerClass="\Drupal\Tests\Listeners\HtmlOutputPrinter">
+
+  <php>
+    <ini name="error_reporting" value="-1"/>
+    <!-- Do not limit the amount of memory tests take to run. -->
+    <ini name="memory_limit" value="-1"/>
+    <!-- Example SIMPLETEST_BASE_URL value: http://localhost -->
+    <env name="SIMPLETEST_BASE_URL" value=""/>
+    <!-- Example SIMPLETEST_DB value: mysql://username:password@localhost/databasename#table_prefix -->
+    <env name="SIMPLETEST_DB" value=""/>
+    <!-- Example BROWSERTEST_OUTPUT_DIRECTORY value: /path/to/webroot/sites/simpletest/browser_output -->
+    <env name="BROWSERTEST_OUTPUT_DIRECTORY" value=""/>
+    <!-- To have browsertest output use an alternative base URL. For example if
+     SIMPLETEST_BASE_URL is an internal DDEV URL, you can set this to the
+     external DDev URL so you can follow the links directly.
+    -->
+    <env name="BROWSERTEST_OUTPUT_BASE_URL" value=""/>
+    <!-- To disable deprecation testing completely uncomment the next line. -->
+    <!-- <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/> -->
+    <!-- Example for changing the driver class for mink tests MINK_DRIVER_CLASS value: 'Drupal\FunctionalJavascriptTests\DrupalSelenium2Driver' -->
+    <env name="MINK_DRIVER_CLASS" value=''/>
+    <!-- Example for changing the driver args to mink tests MINK_DRIVER_ARGS value: '["http://127.0.0.1:8510"]' -->
+    <env name="MINK_DRIVER_ARGS" value=''/>
+    <!-- Example for changing the driver args to webdriver tests MINK_DRIVER_ARGS_WEBDRIVER value: '["chrome", { "chromeOptions": { "w3c": false } }, "http://localhost:4444/wd/hub"]' For using the Firefox browser, replace "chrome" with "firefox" -->
+    <env name="MINK_DRIVER_ARGS_WEBDRIVER" value=''/>
+  </php>
+
+  <testsuites>
+    <testsuite name="unit">
+      <directory>tests/src/Unit</directory>
+    </testsuite>
+  </testsuites>
+
+  <listeners>
+    <listener class="Drupal\Tests\Listeners\DrupalListener"/>
+    <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+  </listeners>
+
+  <!-- Filter for coverage reports. -->
+  <filter>
+    <whitelist>
+      <directory>src</directory>
+    </whitelist>
+  </filter>
+
+</phpunit>

--- a/modules/civiremote_case/src/Api/CaseApi.php
+++ b/modules/civiremote_case/src/Api/CaseApi.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * Copyright (C) 2024 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation in version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Drupal\civiremote_case\Api;
+
+use Drupal\civiremote_entity\Api\AbstractEntityApi;
+
+final class CaseApi extends AbstractEntityApi {
+
+  protected function getRemoteEntityName(): string {
+    return 'RemoteCase';
+  }
+
+}

--- a/modules/civiremote_case/src/Controller/CaseCreateController.php
+++ b/modules/civiremote_case/src/Controller/CaseCreateController.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * Copyright (C) 2024 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation in version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Drupal\civiremote_case\Controller;
+
+use Drupal\civiremote_case\Form\CaseCreateForm;
+use Drupal\Core\Controller\ControllerBase;
+
+final class CaseCreateController extends ControllerBase {
+
+  /**
+   * @phpstan-return array<int|string, mixed> JSON serializable.
+   */
+  public function form(string $profile): array {
+    $form = $this->formBuilder()->getForm(CaseCreateForm::class);
+    $form['#title'] ??= $this->t('Add CiviCRM Case');
+
+    return $form;
+  }
+
+}

--- a/modules/civiremote_case/src/Controller/CaseUpdateController.php
+++ b/modules/civiremote_case/src/Controller/CaseUpdateController.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * Copyright (C) 2024 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation in version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Drupal\civiremote_case\Controller;
+
+use Drupal\civiremote_case\Form\CaseUpdateForm;
+use Drupal\Core\Controller\ControllerBase;
+
+final class CaseUpdateController extends ControllerBase {
+
+  /**
+   * @phpstan-return array<int|string, mixed> JSON serializable.
+   */
+  public function form(string $profile, int $id): array {
+    $form = $this->formBuilder()->getForm(CaseUpdateForm::class);
+    $form['#title'] ??= $this->t('Update CiviCRM Case');
+
+    return $form;
+  }
+
+}

--- a/modules/civiremote_case/src/Form/CaseCreateForm.php
+++ b/modules/civiremote_case/src/Form/CaseCreateForm.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * Copyright (C) 2024 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Drupal\civiremote_case\Form;
+
+use Drupal\civiremote_case\Form\RequestHandler\CaseCreateFormRequestHandler;
+use Drupal\civiremote_entity\Form\AbstractEntityForm;
+use Drupal\civiremote_entity\Form\ResponseHandler\FormResponseHandlerInterface;
+use Drupal\json_forms\Form\FormArrayFactoryInterface;
+use Drupal\json_forms\Form\Validation\FormValidationMapperInterface;
+use Drupal\json_forms\Form\Validation\FormValidatorInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+final class CaseCreateForm extends AbstractEntityForm {
+
+  /**
+   * {@inheritDoc}
+   *
+   * @return static
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get(FormArrayFactoryInterface::class),
+      $container->get(FormValidatorInterface::class),
+      $container->get(FormValidationMapperInterface::class),
+      $container->get(CaseCreateFormRequestHandler::class),
+      $container->get(FormResponseHandlerInterface::class),
+    );
+  }
+
+  public function getFormId(): string {
+    return 'civiremote_case_create_form';
+  }
+
+}

--- a/modules/civiremote_case/src/Form/CaseUpdateForm.php
+++ b/modules/civiremote_case/src/Form/CaseUpdateForm.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * Copyright (C) 2024 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Drupal\civiremote_case\Form;
+
+use Drupal\civiremote_case\Form\RequestHandler\CaseUpdateFormRequestHandler;
+use Drupal\civiremote_entity\Form\AbstractEntityForm;
+use Drupal\civiremote_entity\Form\ResponseHandler\FormResponseHandlerInterface;
+use Drupal\json_forms\Form\FormArrayFactoryInterface;
+use Drupal\json_forms\Form\Validation\FormValidationMapperInterface;
+use Drupal\json_forms\Form\Validation\FormValidatorInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+final class CaseUpdateForm extends AbstractEntityForm {
+
+  /**
+   * {@inheritDoc}
+   *
+   * @return static
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get(FormArrayFactoryInterface::class),
+      $container->get(FormValidatorInterface::class),
+      $container->get(FormValidationMapperInterface::class),
+      $container->get(CaseUpdateFormRequestHandler::class),
+      $container->get(FormResponseHandlerInterface::class),
+    );
+  }
+
+  public function getFormId(): string {
+    return 'civiremote_case_update_form';
+  }
+
+}

--- a/modules/civiremote_case/src/Form/RequestHandler/CaseCreateFormRequestHandler.php
+++ b/modules/civiremote_case/src/Form/RequestHandler/CaseCreateFormRequestHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * Copyright (C) 2024 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation in version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Drupal\civiremote_case\Form\RequestHandler;
+
+use Drupal\civiremote_case\Api\CaseApi;
+use Drupal\civiremote_entity\Form\RequestHandler\EntityCreateFormRequestHandler;
+
+final class CaseCreateFormRequestHandler extends EntityCreateFormRequestHandler {
+
+  // For autowiring:
+  // phpcs:disable Generic.CodeAnalysis.UselessOverridingMethod.Found
+  public function __construct(CaseApi $caseApi) {
+  // phpcs:enable
+    parent::__construct($caseApi);
+  }
+
+}

--- a/modules/civiremote_case/src/Form/RequestHandler/CaseUpdateFormRequestHandler.php
+++ b/modules/civiremote_case/src/Form/RequestHandler/CaseUpdateFormRequestHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * Copyright (C) 2024 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation in version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Drupal\civiremote_case\Form\RequestHandler;
+
+use Drupal\civiremote_case\Api\CaseApi;
+use Drupal\civiremote_entity\Form\RequestHandler\EntityUpdateFormRequestHandler;
+
+final class CaseUpdateFormRequestHandler extends EntityUpdateFormRequestHandler {
+
+  // For autowiring:
+  // phpcs:disable Generic.CodeAnalysis.UselessOverridingMethod.Found
+  public function __construct(CaseApi $caseApi) {
+    // phpcs:enable
+    parent::__construct($caseApi);
+  }
+
+}

--- a/modules/civiremote_case/tools/phpstan/composer.json
+++ b/modules/civiremote_case/tools/phpstan/composer.json
@@ -1,0 +1,18 @@
+{
+    "require": {
+        "phpstan/extension-installer": "^1.1",
+        "phpstan/phpstan": "^1.7",
+        "phpstan/phpstan-beberlei-assert": "^1.0",
+        "phpstan/phpstan-deprecation-rules": "^1.0",
+        "phpstan/phpstan-phpunit": "^1.1",
+        "phpstan/phpstan-strict-rules": "^1.2",
+        "thecodingmachine/phpstan-strict-rules": "^1.0",
+        "voku/phpstan-rules": "^3"
+    },
+    "config": {
+        "allow-plugins": {
+            "phpstan/extension-installer": true
+        },
+        "sort-packages": true
+    }
+}

--- a/modules/civiremote_entity/src/Access/RemoteContactIdProvider.php
+++ b/modules/civiremote_entity/src/Access/RemoteContactIdProvider.php
@@ -20,7 +20,6 @@ declare(strict_types=1);
 
 namespace Drupal\civiremote_entity\Access;
 
-use Assert\Assertion;
 use Drupal\Core\Session\AccountProxyInterface;
 
 final class RemoteContactIdProvider implements RemoteContactIdProviderInterface {
@@ -31,16 +30,33 @@ final class RemoteContactIdProvider implements RemoteContactIdProviderInterface 
     $this->currentUser = $currentUser;
   }
 
+  /**
+   * @{inheritDoc}
+   */
   public function getRemoteContactId(): string {
+    if (!$this->hasRemoteContactId()) {
+      throw new \RuntimeException(sprintf('User "%s" has no remote contact ID', $this->currentUser->getAccountName()));
+    }
+
+    // @phpstan-ignore property.notFound
+    return $this->currentUser->getAccount()->civiremote_id;
+  }
+
+  /**
+   * @{inheritDoc}
+   */
+  public function getRemoteContactIdOrNull(): ?string {
+    return $this->hasRemoteContactId() ? $this->getRemoteContactId() : NULL;
+  }
+
+  /**
+   * @{inheritDoc}
+   */
+  public function hasRemoteContactId(): bool {
     $account = $this->currentUser->getAccount();
-    Assertion::propertyExists($account, 'civiremote_id');
-    // @phpstan-ignore-next-line
-    $remoteContactId = $account->civiremote_id;
+    $remoteContactId = $account->civiremote_id ?? NULL;
 
-    Assertion::string($remoteContactId);
-    Assertion::notEmpty($remoteContactId);
-
-    return $remoteContactId;
+    return is_string($remoteContactId) && '' !== $remoteContactId;
   }
 
 }

--- a/modules/civiremote_entity/src/Access/RemoteContactIdProviderInterface.php
+++ b/modules/civiremote_entity/src/Access/RemoteContactIdProviderInterface.php
@@ -22,6 +22,19 @@ namespace Drupal\civiremote_entity\Access;
 
 interface RemoteContactIdProviderInterface {
 
+  /**
+   * @throws \RuntimeException
+   *   If current user has no remote contact ID.
+   */
   public function getRemoteContactId(): string;
+
+  /**
+   * @return string|null
+   *   The user's remote contact ID, or NULL if the user has no remote contact
+   *   ID.
+   */
+  public function getRemoteContactIdOrNull(): ?string;
+
+  public function hasRemoteContactId(): bool;
 
 }

--- a/modules/civiremote_entity/src/Api/AbstractEntityApi.php
+++ b/modules/civiremote_entity/src/Api/AbstractEntityApi.php
@@ -46,7 +46,7 @@ abstract class AbstractEntityApi {
     $result = $this->client->executeV4($this->getRemoteEntityName(), 'getCreateForm', [
       'profile' => $profile,
       'arguments' => $arguments,
-      'remoteContactId' => $this->remoteContactIdProvider->getRemoteContactId(),
+      'remoteContactId' => $this->remoteContactIdProvider->getRemoteContactIdOrNull(),
     ]);
 
     return EntityForm::fromApiResultValue($result['values']);
@@ -61,7 +61,7 @@ abstract class AbstractEntityApi {
       'profile' => $profile,
       'data' => $data,
       'arguments' => $arguments,
-      'remoteContactId' => $this->remoteContactIdProvider->getRemoteContactId(),
+      'remoteContactId' => $this->remoteContactIdProvider->getRemoteContactIdOrNull(),
     ]);
 
     return FormSubmitResponse::fromApiResultValue($result['values']);
@@ -76,7 +76,7 @@ abstract class AbstractEntityApi {
       'profile' => $profile,
       'data' => $data,
       'arguments' => $arguments,
-      'remoteContactId' => $this->remoteContactIdProvider->getRemoteContactId(),
+      'remoteContactId' => $this->remoteContactIdProvider->getRemoteContactIdOrNull(),
     ]);
 
     return FormValidationResponse::fromApiResultValue($result['values']);
@@ -86,7 +86,7 @@ abstract class AbstractEntityApi {
     $result = $this->client->executeV4($this->getRemoteEntityName(), 'getUpdateForm', [
       'profile' => $profile,
       'id' => $id,
-      'remoteContactId' => $this->remoteContactIdProvider->getRemoteContactId(),
+      'remoteContactId' => $this->remoteContactIdProvider->getRemoteContactIdOrNull(),
     ]);
 
     return EntityForm::fromApiResultValue($result['values']);
@@ -100,7 +100,7 @@ abstract class AbstractEntityApi {
       'profile' => $profile,
       'id' => $id,
       'data' => $data,
-      'remoteContactId' => $this->remoteContactIdProvider->getRemoteContactId(),
+      'remoteContactId' => $this->remoteContactIdProvider->getRemoteContactIdOrNull(),
     ]);
 
     return FormSubmitResponse::fromApiResultValue($result['values']);
@@ -114,7 +114,7 @@ abstract class AbstractEntityApi {
       'profile' => $profile,
       'id' => $id,
       'data' => $data,
-      'remoteContactId' => $this->remoteContactIdProvider->getRemoteContactId(),
+      'remoteContactId' => $this->remoteContactIdProvider->getRemoteContactIdOrNull(),
     ]);
 
     return FormValidationResponse::fromApiResultValue($result['values']);


### PR DESCRIPTION
The corresponding CiviCRM extension is here: https://github.com/systopia/remote_case

It's basically the same as in `civicremote_activity` adapted for cases.

systopia-reference: 25874