### PR TITLE
Remove margin between file input field and link

### DIFF
--- a/modules/civiremote_entity/civiremote_entity.libraries.yml
+++ b/modules/civiremote_entity/civiremote_entity.libraries.yml
@@ -1,0 +1,4 @@
+file-field:
+  css:
+    theme:
+      css/file-field.css: {}

--- a/modules/civiremote_entity/css/file-field.css
+++ b/modules/civiremote_entity/css/file-field.css
@@ -1,0 +1,9 @@
+.form-item:has(+.civiremote-form-file-link) {
+  /* No margin between file form item and link. */
+  margin-bottom: 0;
+}
+
+.civiremote-form-file-link {
+  /* No margin between file form item and link. */
+  margin-top: 0;
+}

--- a/modules/civiremote_entity/src/Form/Control/FileArrayFactory.php
+++ b/modules/civiremote_entity/src/Form/Control/FileArrayFactory.php
@@ -72,6 +72,9 @@ class FileArrayFactory extends AbstractConcreteFormArrayFactory {
       && is_string($form['file']['#default_value']->url ?? NULL)
       && is_string($form['file']['#default_value']->filename ?? NULL)
     ) {
+      // @phpstan-ignore offsetAccess.nonOffsetAccessible, offsetAccess.nonOffsetAccessible
+      $form['file']['#attached']['library'][] = 'civiremote_entity/file-field';
+
       $url = $form['file']['#default_value']->url;
       $filename = $form['file']['#default_value']->filename;
 
@@ -82,7 +85,7 @@ class FileArrayFactory extends AbstractConcreteFormArrayFactory {
         '#title' => $filename,
         '#url' => $this->civiCRMUrlManager->addRemoteUrl($url, $filename),
         '#attributes' => ['target' => '_blank'],
-        '#prefix' => '<p>',
+        '#prefix' => '<p class="civiremote-form-file-link">',
         '#suffix' => '</p>',
       ];
 


### PR DESCRIPTION
The file input field is wrapped by a `div` with class `.form-item` and thus gets a bottom margin. The `p` element containing the link to the current file has a top margin. So there is a lot of space between input field and link. This change sets these margins to `0`.

systopia-reference: 25904