### PR TITLE
[civiremote_entity] Rebuild form in case of error

### DIFF
--- a/modules/civiremote_entity/src/Form/AbstractEntityForm.php
+++ b/modules/civiremote_entity/src/Form/AbstractEntityForm.php
@@ -119,6 +119,7 @@ abstract class AbstractEntityForm extends AbstractJsonFormsForm {
     }
     catch (ApiCallFailedException $e) {
       $this->messenger()->addError($this->t('Submitting form failed: @error', ['@error' => $e->getMessage()]));
+      $formState->setRebuild(TRUE);
 
       return;
     }


### PR DESCRIPTION
Previously on error a redirect to the destination (URL parameter) was executed, if given. Otherwise, a redirect to the form page was executed. Now in both cases the form is rebuild (so the entered values are kept).