### PR TITLE
D11 incompatibility: Replace use of deprecated/removed `user_role_names()`

### DIFF
--- a/civiremote.info.yml
+++ b/civiremote.info.yml
@@ -3,7 +3,7 @@ type: module
 description: 'Core and Tools module for CiviRemote'
 package: CiviCRM
 core: 8.x
-core_version_requirement: ^8 || ^9 || ^10
+core_version_requirement: ^8 || ^9 || ^10 || ^11
 configure: civiremote.config_form
 dependencies:
   - cmrf_core

--- a/modules/civiremote_event/civiremote_event.info.yml
+++ b/modules/civiremote_event/civiremote_event.info.yml
@@ -3,7 +3,7 @@ type: module
 description: 'CiviRemote Events'
 package: CiviCRM
 core: 8.x
-core_version_requirement: ^8 || ^9 || ^10
+core_version_requirement: ^8 || ^9 || ^10 || ^11
 configure: civiremote_event.config_form
 dependencies:
   - civiremote

--- a/src/User.php
+++ b/src/User.php
@@ -19,6 +19,7 @@ use Drupal;
 use Drupal\Core\Entity;
 use Drupal\user\UserInterface;
 use Drupal\user\Entity\Role;
+use Drupal\user\RoleInterface;
 
 /**
  * Class User
@@ -167,9 +168,13 @@ class User {
       }
 
       // Fetch all CiviRemote roles known to Drupal.
-      $all_roles = user_role_names(TRUE);
+      $allRoles = array_filter(
+        Role::loadMultiple(),
+        fn(RoleInterface $role) => RoleInterface::ANONYMOUS_ID !== $role->id()
+      );
+      $allRoleNames = array_map(fn(RoleInterface $role) => $role->label(), $allRoles);
       $civiremote_roles = [];
-      foreach ($all_roles as $id => $label) {
+      foreach ($allRoleNames as $id => $label) {
         if (strpos($id, 'civiremote_') === 0) {
           $civiremote_roles[$id] = $label;
         }
@@ -179,7 +184,7 @@ class User {
       $user_civiremote_roles = [];
       foreach ($user->getRoles() as $id) {
         if (strpos($id, 'civiremote_') === 0) {
-          $user_civiremote_roles[$id] = $all_roles[$id];
+          $user_civiremote_roles[$id] = $allRoleNames[$id];
         }
       }
 

--- a/src/User.php
+++ b/src/User.php
@@ -168,14 +168,10 @@ class User {
       }
 
       // Fetch all CiviRemote roles known to Drupal.
-      $allRoles = array_filter(
-        Role::loadMultiple(),
-        fn(RoleInterface $role) => RoleInterface::ANONYMOUS_ID !== $role->id()
-      );
-      $allRoleNames = array_map(fn(RoleInterface $role) => $role->label(), $allRoles);
+      $allRoleNames = array_map(fn(RoleInterface $role) => $role->label(), Role::loadMultiple());
       $civiremote_roles = [];
       foreach ($allRoleNames as $id => $label) {
-        if (strpos($id, 'civiremote_') === 0) {
+        if (str_starts_with($id, 'civiremote_')) {
           $civiremote_roles[$id] = $label;
         }
       }
@@ -183,7 +179,7 @@ class User {
       // Fetch the user's current CiviRemote roles.
       $user_civiremote_roles = [];
       foreach ($user->getRoles() as $id) {
-        if (strpos($id, 'civiremote_') === 0) {
+        if (str_starts_with($id, 'civiremote_')) {
           $user_civiremote_roles[$id] = $allRoleNames[$id];
         }
       }


### PR DESCRIPTION
*systopia-reference: 29645*

Related Drupal Core Change Record: https://www.drupal.org/node/3349759

This adds `^11` to `core_version_requirement` for the base module and the `civiremote_event` submodule although full compatibility has not been checked yet.