### PR TITLE
Match during presave when unblocking users

### DIFF
--- a/civiremote.module
+++ b/civiremote.module
@@ -6,19 +6,15 @@ use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\user\UserInterface;
 
 /**
- * Implements hook_ENTITY_TYPE_insert().
- */
-function civiremote_user_insert(UserInterface $user): void {
-  civiremote\User::onInsert($user);
-}
-
-/**
  * Implements hook_ENTITY_TYPE_presave().
  */
 function civiremote_user_presave(UserInterface $user): void {
-  /** @var \Drupal\user\UserInterface $original */
+  /** @var \Drupal\user\UserInterface|null $original */
   $original = $user->original;
-  if ($original->isBlocked() && !$user->isBlocked()) {
+  if (NULL === $original) {
+    civiremote\User::onInsert($user);
+  }
+  elseif ($original->isBlocked() && !$user->isBlocked()) {
     civiremote\User::onUnblock($user);
   }
 }

--- a/civiremote.module
+++ b/civiremote.module
@@ -13,9 +13,9 @@ function civiremote_user_insert(UserInterface $user): void {
 }
 
 /**
- * Implements hook_ENTITY_TYPE_update().
+ * Implements hook_ENTITY_TYPE_presave().
  */
-function civiremote_user_update(UserInterface $user): void {
+function civiremote_user_presave(UserInterface $user): void {
   /** @var \Drupal\user\UserInterface $original */
   $original = $user->original;
   if ($original->isBlocked() && !$user->isBlocked()) {

--- a/src/Plugin/Action/UserMatchContact.php
+++ b/src/Plugin/Action/UserMatchContact.php
@@ -50,7 +50,9 @@ class UserMatchContact extends ActionBase {
     if (!$civiremote_id = $user->get('civiremote_id')->getValue()) {
       $config = Drupal::config('civiremote.settings');
       if ($config->get('acquire_civiremote_id')) {
-        User::matchContact($user);
+        if (NULL !== User::matchContact($user)) {
+          $user->save();
+        }
       }
     }
   }

--- a/src/User.php
+++ b/src/User.php
@@ -39,9 +39,7 @@ class User {
   public static function onInsert(UserInterface $user) {
     $config = Drupal::config('civiremote.settings');
     if ($config->get('acquire_civiremote_id')) {
-      if (NULL !== self::matchContact($user)) {
-        $user->save();
-      }
+      self::matchContact($user);
     }
   }
 

--- a/src/User.php
+++ b/src/User.php
@@ -39,7 +39,9 @@ class User {
   public static function onInsert(UserInterface $user) {
     $config = Drupal::config('civiremote.settings');
     if ($config->get('acquire_civiremote_id')) {
-      self::matchContact($user);
+      if (NULL !== self::matchContact($user)) {
+        $user->save();
+      }
     }
   }
 
@@ -58,7 +60,9 @@ class User {
           && ($config->get('match_on_login') ?? FALSE)
           && [] === array_intersect($user->getRoles(), $config->get('match_on_login_exclude_roles') ?? [])
         ) {
-          self::matchContact($user);
+          if (NULL !== self::matchContact($user)) {
+            $user->save();
+          }
         }
       }
 
@@ -89,7 +93,7 @@ class User {
         && ($config->get('match_on_unblock') ?? FALSE)
       ) {
         // Update the user object, but do not save, as we're in a save action already.
-        self::matchContact($user, '', FALSE);
+        self::matchContact($user);
       }
     }
     catch (\Exception $exception) {
@@ -101,30 +105,31 @@ class User {
 
   /**
    * Match a CiviCRM contact and set the returned CiviRemote ID on the user.
+   * The user object will not be saved and needs to be saved manually by calling \Drupal\user\UserInterface::save().
    *
-   * @param UserInterface $user
+   * @param Drupal\user\UserInterface $user
    *   The User entity object.
    * @param string $prefix
    *   A prefix to be added to the CiviRemote ID by the CiviRemote API.
-   * @param bool $save
-   *   Whether to save the user object to the database. Will only update the
-   *   $user object otherwise.
+   *
+   * @return string|null
+   *   The acquired CivIRemote ID, or NULL if none was acquired.
    *
    * @throws Entity\EntityStorageException
    */
-  public static function matchContact(UserInterface $user, $prefix = '', $save = TRUE) {
+  public static function matchContact(UserInterface $user, string $prefix = ''): ?string {
     /* @var \Drupal\civiremote\CiviMRF $cmrf */
     $cmrf = Drupal::service('civiremote.cmrf');
     $config = Drupal::config('civiremote.settings');
 
     // Only match locked users when configured.
     if ($user->isBlocked() && !($config->get('match_blocked_users') ?? FALSE)) {
-      return;
+      return NULL;
     }
     $params = [];
 
     // Use base URL as default key prefix.
-    if (empty($prefix)) {
+    if ('' === $prefix) {
       global $base_url;
       $base_url_parts = parse_url($base_url);
       $prefix = $base_url_parts['host'];
@@ -139,10 +144,10 @@ class User {
     // Send API call and store the returned CiviRemote ID.
     if ($civiremote_id = $cmrf->matchContact($params)) {
       $user->set('civiremote_id', $civiremote_id);
-      if ($save) {
-        $user->save();
-      }
+      return $civiremote_id;
     }
+
+    return NULL;
   }
 
   /**

--- a/src/User.php
+++ b/src/User.php
@@ -88,7 +88,8 @@ class User {
         $config->get('acquire_civiremote_id')
         && ($config->get('match_on_unblock') ?? FALSE)
       ) {
-        self::matchContact($user);
+        // Update the user object, but do not save, as we're in a save action already.
+        self::matchContact($user, '', FALSE);
       }
     }
     catch (\Exception $exception) {
@@ -105,10 +106,13 @@ class User {
    *   The User entity object.
    * @param string $prefix
    *   A prefix to be added to the CiviRemote ID by the CiviRemote API.
+   * @param bool $save
+   *   Whether to save the user object to the database. Will only update the
+   *   $user object otherwise.
    *
    * @throws Entity\EntityStorageException
    */
-  public static function matchContact(UserInterface $user, $prefix = '') {
+  public static function matchContact(UserInterface $user, $prefix = '', $save = TRUE) {
     /* @var \Drupal\civiremote\CiviMRF $cmrf */
     $cmrf = Drupal::service('civiremote.cmrf');
     $config = Drupal::config('civiremote.settings');
@@ -135,7 +139,9 @@ class User {
     // Send API call and store the returned CiviRemote ID.
     if ($civiremote_id = $cmrf->matchContact($params)) {
       $user->set('civiremote_id', $civiremote_id);
-      $user->save();
+      if ($save) {
+        $user->save();
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #47.

Matching users during the *Unblock user* operation happens inside a `save` action and thus the user object must not be saved again, as this would cause an infinite loop. In order to apply the matched CiviRemote ID, matching is now done in the `presave` hook so that the acquired CiviRemote ID will be saved alongside the original changes (at least status from `0` to `1` in this case).

*systopia-reference: 26311*