### PR TITLE
[civiremote_entity] Allow to specify the HTTP method for form submit

### DIFF
--- a/modules/civiremote_entity/src/Form/AbstractEntityForm.php
+++ b/modules/civiremote_entity/src/Form/AbstractEntityForm.php
@@ -72,7 +72,7 @@ abstract class AbstractEntityForm extends AbstractJsonFormsForm {
       $form_state->set('uiSchema', $entityForm->getUiSchema());
     }
 
-    return $this->buildJsonFormsForm(
+    $form = $this->buildJsonFormsForm(
       $form,
       $form_state,
       // @phpstan-ignore-next-line
@@ -81,6 +81,18 @@ abstract class AbstractEntityForm extends AbstractJsonFormsForm {
       $form_state->get('uiSchema'),
       self::FLAG_RECALCULATE_ONCHANGE
     );
+
+    // @phpstan-ignore property.nonObject
+    $submitMethod = $form_state->get('uiSchema')->options->submitMethod ?? NULL;
+    if (NULL !== $submitMethod) {
+      $form['#method'] = $submitMethod;
+      if ('GET' === $submitMethod && TRUE !== $form_state->get('$calculateUsed')) {
+        // Prevent some Drupal specific parameters in URL query.
+        $form['#after_build'][] = [static::class, 'onAfterBuild'];
+      }
+    }
+
+    return $form;
   }
 
   public function validateForm(array &$form, FormStateInterface $formState): void {
@@ -148,6 +160,20 @@ abstract class AbstractEntityForm extends AbstractJsonFormsForm {
     unset($data['_submit']);
 
     return $data;
+  }
+
+  /**
+   * @param array<int|string, mixed> $form
+   *
+   * @return array<int|string, mixed>
+   */
+  public static function onAfterBuild(array $form, FormStateInterface $formState): array {
+    // @phpstan-ignore offsetAccess.nonOffsetAccessible
+    $form['form_build_id']['#access'] = FALSE;
+    $form['form_id']['#access'] = FALSE;
+    $form['form_token']['#access'] = FALSE;
+
+    return $form;
   }
 
 }

--- a/modules/civiremote_entity/src/Form/RequestHandler/EntityCreateFormRequestHandler.php
+++ b/modules/civiremote_entity/src/Form/RequestHandler/EntityCreateFormRequestHandler.php
@@ -41,7 +41,7 @@ class EntityCreateFormRequestHandler implements FormRequestHandlerInterface {
     $profile = $routeMatch->getParameter('profile');
     Assertion::string($profile);
 
-    return $this->entityApi->getCreateForm($profile);
+    return $this->entityApi->getCreateForm($profile, $this->getArguments($request, NULL));
   }
 
   public function validateForm(Request $request, array $data): FormValidationResponse {
@@ -49,7 +49,7 @@ class EntityCreateFormRequestHandler implements FormRequestHandlerInterface {
     $profile = $routeMatch->getParameter('profile');
     Assertion::string($profile);
 
-    return $this->entityApi->validateCreateForm($profile, $data);
+    return $this->entityApi->validateCreateForm($profile, $data, $this->getArguments($request, $data));
   }
 
   public function submitForm(Request $request, array $data): FormSubmitResponse {
@@ -57,7 +57,16 @@ class EntityCreateFormRequestHandler implements FormRequestHandlerInterface {
     $profile = $routeMatch->getParameter('profile');
     Assertion::string($profile);
 
-    return $this->entityApi->submitCreateForm($profile, $data);
+    return $this->entityApi->submitCreateForm($profile, $data, $this->getArguments($request, $data));
+  }
+
+  /**
+   * @param array<int|string, mixed>|null $data
+   *
+   * @return array<int|string, mixed>
+   */
+  protected function getArguments(Request $request, ?array $data): array {
+    return $request->query->all();
   }
 
 }


### PR DESCRIPTION
The form submit method can be specified with the attribute `submitMethod` in the options object of the root UI schema element.

systopia-reference: 30384