### PR TITLE
[civiremote_entity] Redirect to entity update page after entity creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,27 @@
 CiviRemote
 ===========
 
-The *CiviRemote* module, and included sub-modules, is a front-end implementation
+The *CiviRemote* module, and included submodules, is a front-end implementation
 of the [*CiviRemote*](https://github.com/systopia/de.systopia.remotetools)
 framework, and specifically for the [*CiviRemote
 Event* CiviCRM extension](https://github.com/systopia/de.systopia.remoteevent),
 allowing for CiviCRM event registration (including update/cancellation) on a
 Drupal website with connection to a CiviCRM instance via the [
 *CiviMRF*](https://drupal.org/project/cmrf_core) framework.
+
+## CiviRemote Entity
+
+The submodule [*CiviRemote Entity*](modules/civiremote_entity) contains base
+classes for remote entity forms to create and update CiviCRM entities via
+remote API built with
+[*CiviRemote*](https://github.com/systopia/de.systopia.remotetools). You can
+find an implementation for the *Case* entity in
+[modules/civiremote_case](modules/civiremote_case) that can be used as template
+for other entities.
+
+*CiviRemote Entity* contains a
+[response handler](modules/civiremote_entity/src/Form/ResponseHandler/FormResponseHandlerRedirect.php)
+that tries to redirect to the update form after entity creation. It should work
+in most cases. If a concrete submodule uses non-standard paths, it is always
+possible to use custom response handlers when creating the
+[`AbstractEntityForm`](modules/civiremote_entity/src/Form/AbstractEntityForm.php).

--- a/modules/civiremote_entity/civiremote_entity.services.yml
+++ b/modules/civiremote_entity/civiremote_entity.services.yml
@@ -28,10 +28,19 @@ services:
     arguments:
       - '@current_user'
 
-  Drupal\civiremote_entity\Form\ResponseHandler\FormResponseHandlerInterface:
+  Drupal\civiremote_entity\Form\ResponseHandler\FormResponseHandlerMessage:
     class: Drupal\civiremote_entity\Form\ResponseHandler\FormResponseHandlerMessage
     arguments:
       $messenger: '@messenger'
+
+  Drupal\civiremote_entity\Form\ResponseHandler\FormResponseHandlerRedirect:
+    class: Drupal\civiremote_entity\Form\ResponseHandler\FormResponseHandlerRedirect
+
+  Drupal\civiremote_entity\Form\ResponseHandler\FormResponseHandlerInterface:
+    class: Drupal\civiremote_entity\Form\ResponseHandler\FormResponseHandlerChain
+    arguments:
+      - '@Drupal\civiremote_entity\Form\ResponseHandler\FormResponseHandlerMessage'
+      - '@Drupal\civiremote_entity\Form\ResponseHandler\FormResponseHandlerRedirect'
     public: true
 
   Drupal\civiremote_entity\CiviCRMPage\CiviCRMPageClientInterface:

--- a/modules/civiremote_entity/src/Api/Form/FormSubmitResponse.php
+++ b/modules/civiremote_entity/src/Api/Form/FormSubmitResponse.php
@@ -22,21 +22,41 @@ namespace Drupal\civiremote_entity\Api\Form;
 
 class FormSubmitResponse {
 
-  private string $message;
+  /**
+   * @var array<int|string, mixed>
+   */
+  private array $response;
 
   /**
-   * @phpstan-param array{message: string} $value
+   * @param array<int|string, mixed> $value
    */
   public static function fromApiResultValue(array $value): self {
-    return new self($value['message']);
+    return new self($value);
   }
 
-  public function __construct(string $message) {
-    $this->message = $message;
+  /**
+   * @param array<int|string, mixed> $response
+   */
+  protected function __construct(array $response) {
+    $this->response = $response;
   }
 
-  public function getMessage(): string {
-    return $this->message;
+  public function getEntityId(): ?int {
+    // @phpstan-ignore return.type
+    return $this->get('entityId');
+  }
+
+  public function getMessage(): ?string {
+    // @phpstan-ignore return.type
+    return $this->get('message');
+  }
+
+  public function get(int|string $key, mixed $default = NULL): mixed {
+    return $this->response[$key] ?? $default;
+  }
+
+  public function has(int|string $key): bool {
+    return array_key_exists($key, $this->response);
   }
 
 }

--- a/modules/civiremote_entity/src/Form/AbstractEntityForm.php
+++ b/modules/civiremote_entity/src/Form/AbstractEntityForm.php
@@ -138,7 +138,7 @@ abstract class AbstractEntityForm extends AbstractJsonFormsForm {
       return;
     }
 
-    $this->formResponseHandler->handleSubmitResponse($submitResponse, $formState);
+    $this->formResponseHandler->handleSubmitResponse($this->getRequest(), $submitResponse, $formState);
   }
 
   /**

--- a/modules/civiremote_entity/src/Form/ResponseHandler/FormResponseHandlerChain.php
+++ b/modules/civiremote_entity/src/Form/ResponseHandler/FormResponseHandlerChain.php
@@ -22,6 +22,7 @@ namespace Drupal\civiremote_entity\Form\ResponseHandler;
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\civiremote_entity\Api\Form\FormSubmitResponse;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @codeCoverageIgnore
@@ -37,9 +38,13 @@ final class FormResponseHandlerChain implements FormResponseHandlerInterface {
     $this->formResponseHandlers = $formResponseHandlers;
   }
 
-  public function handleSubmitResponse(FormSubmitResponse $submitResponse, FormStateInterface $formState): void {
+  public function handleSubmitResponse(
+    Request $request,
+    FormSubmitResponse $submitResponse,
+    FormStateInterface $formState
+  ): void {
     foreach ($this->formResponseHandlers as $formResponseHandler) {
-      $formResponseHandler->handleSubmitResponse($submitResponse, $formState);
+      $formResponseHandler->handleSubmitResponse($request, $submitResponse, $formState);
     }
   }
 

--- a/modules/civiremote_entity/src/Form/ResponseHandler/FormResponseHandlerInterface.php
+++ b/modules/civiremote_entity/src/Form/ResponseHandler/FormResponseHandlerInterface.php
@@ -22,9 +22,14 @@ namespace Drupal\civiremote_entity\Form\ResponseHandler;
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\civiremote_entity\Api\Form\FormSubmitResponse;
+use Symfony\Component\HttpFoundation\Request;
 
 interface FormResponseHandlerInterface {
 
-  public function handleSubmitResponse(FormSubmitResponse $submitResponse, FormStateInterface $formState): void;
+  public function handleSubmitResponse(
+    Request $request,
+    FormSubmitResponse $submitResponse,
+    FormStateInterface $formState
+  ): void;
 
 }

--- a/modules/civiremote_entity/src/Form/ResponseHandler/FormResponseHandlerMessage.php
+++ b/modules/civiremote_entity/src/Form/ResponseHandler/FormResponseHandlerMessage.php
@@ -24,6 +24,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\civiremote_entity\Api\Form\FormSubmitResponse;
+use Symfony\Component\HttpFoundation\Request;
 
 class FormResponseHandlerMessage implements FormResponseHandlerInterface {
 
@@ -35,8 +36,14 @@ class FormResponseHandlerMessage implements FormResponseHandlerInterface {
     $this->messenger = $messenger;
   }
 
-  public function handleSubmitResponse(FormSubmitResponse $submitResponse, FormStateInterface $formState): void {
-    $this->messenger->addMessage($submitResponse->getMessage());
+  public function handleSubmitResponse(
+    Request $request,
+    FormSubmitResponse $submitResponse,
+    FormStateInterface $formState
+  ): void {
+    if (NULL !== $submitResponse->getMessage()) {
+      $this->messenger->addMessage($submitResponse->getMessage());
+    }
   }
 
 }

--- a/modules/civiremote_entity/src/Form/ResponseHandler/FormResponseHandlerRedirect.php
+++ b/modules/civiremote_entity/src/Form/ResponseHandler/FormResponseHandlerRedirect.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * Copyright (C) 2025 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Drupal\civiremote_entity\Form\ResponseHandler;
+
+use Drupal\civiremote_entity\Api\Form\FormSubmitResponse;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Redirect to entity update page after entity creation, if possible.
+ */
+final class FormResponseHandlerRedirect implements FormResponseHandlerInterface {
+
+  public function handleSubmitResponse(
+    Request $request,
+    FormSubmitResponse $submitResponse,
+    FormStateInterface $formState
+  ): void {
+    if (NULL !== $submitResponse->getEntityId()) {
+      $currentUrl = Url::createFromRequest($request);
+      $path = $currentUrl->getInternalPath();
+      if (str_contains($path, '/add/')) {
+        $path = '/' . str_replace('/add/', '/' . $submitResponse->getEntityId() . '/update/', $path);
+        $url = Url::fromUserInput($path);
+        if ($url->isRouted()) {
+          $formState->setRedirectUrl($url);
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
This tries to redirect to the entity update page after entity creation in a generic way by replacing `/add/` with `/<entity ID>/update/` and checking if it matches a route.

systopia-reference: 30384