### PR TITLE
Return NULL when route parameter conversion fails instead of throwing an exception

### DIFF
--- a/modules/civiremote_event/src/Routing/CheckinTokenConverter.php
+++ b/modules/civiremote_event/src/Routing/CheckinTokenConverter.php
@@ -52,7 +52,7 @@ class CheckinTokenConverter implements ParamConverterInterface {
     }
     catch (Exception $exception) {
       Utils::setMessages([['message' => $exception->getMessage(), 'severity' => 'error']]);
-      throw new AccessDeniedHttpException($exception->getMessage());
+      return NULL;
     }
   }
 

--- a/modules/civiremote_event/src/Routing/CiviRemoteEventConverter.php
+++ b/modules/civiremote_event/src/Routing/CiviRemoteEventConverter.php
@@ -50,7 +50,7 @@ class CiviRemoteEventConverter implements ParamConverterInterface {
     }
     catch (Exception $exception) {
       Utils::setMessages([['message' => $exception->getMessage(), 'severity' => 'error']]);
-      throw new AccessDeniedHttpException($exception->getMessage());
+      return NULL;
     }
   }
 

--- a/modules/civiremote_event/src/Routing/EventTokenConverter.php
+++ b/modules/civiremote_event/src/Routing/EventTokenConverter.php
@@ -50,7 +50,7 @@ class EventTokenConverter implements ParamConverterInterface {
     }
     catch (Exception $exception) {
       Utils::setMessages([['message' => $exception->getMessage(), 'severity' => 'error']]);
-      throw new AccessDeniedHttpException($exception->getMessage());
+      return NULL;
     }
   }
 


### PR DESCRIPTION
Throwing an exception will cause the route object not being constructed regularly, which will fail in `\Drupal\Core\EventSubscriber\CsrfExceptionSubscriber`, see https://www.drupal.org/project/drupal/issues/3511584.

Returning `NULL` instead effectively turns an invalid route parameter into a *404 Not Found* instead of a *403 Access Denied* response, which is actually more appropriate. Most (if not all) core implementations also return `NULL` instead of throwing an exception, so this seems to be best practice implicitly.